### PR TITLE
Use external files dir for getting modloader, various cleanup

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,7 @@
+BasedOnStyle: Google
+IndentWidth: 2
+ColumnLimit: 120
+Language: Cpp
+# Force pointers to the type for C++.
+DerivePointerAlignment: false
+PointerAlignment: Left

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 build/
+.cache/
+.o
+.so
+ndkpath.txt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ set(SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src)
 set(INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 # compile options used
-add_compile_options(-frtti -fPIE -fPIC -fexceptions -O3)
+add_compile_options(-frtti -fPIE -fPIC -fno-exceptions -O3)
 
 # recursively get all src files
 RECURSE_FILES(cpp_file_list ${SOURCE_DIR}/*.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ set(SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src)
 set(INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 # compile options used
-add_compile_options(-fPIE -flto -fPIC -fno-exceptions -O3 -Oz)
+add_compile_options(-fPIE -flto -fPIC -fno-exceptions -O3 -Oz -fvisibility=hidden -Wall -Wextra -Wpedantic -Werror)
 
 # recursively get all src files
 RECURSE_FILES(cpp_file_list ${SOURCE_DIR}/*.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ set(ANDROID_PLATFORM 24)
 set(ANDROID_ABI arm64-v8a)
 set(ANDROID_STL c++_static)
 set(ANDROID_USE_LEGACY_TOOLCHAIN_FILE OFF)
-
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_TOOLCHAIN_FILE ${CMAKE_ANDROID_NDK}/build/cmake/android.toolchain.cmake)
 # define used for external data, mostly just the qpm dependencies
 set(EXTERN_DIR ${CMAKE_CURRENT_SOURCE_DIR}/${EXTERN_DIR_NAME})
@@ -59,7 +59,7 @@ set(SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src)
 set(INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 # compile options used
-add_compile_options(-frtti -fPIE -fPIC -fno-exceptions -O3)
+add_compile_options(-fPIE -flto -fPIC -fno-exceptions -O3 -Oz)
 
 # recursively get all src files
 RECURSE_FILES(cpp_file_list ${SOURCE_DIR}/*.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ set(SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src)
 set(INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 # compile options used
-add_compile_options(-fPIE -flto -fPIC -fno-exceptions -O3 -Oz -fvisibility=hidden -Wall -Wextra -Wpedantic -Werror)
+add_compile_options(-fPIE -flto -fPIC -fno-rtti -fno-exceptions -O3 -Oz -fvisibility=hidden -Wall -Wextra -Wpedantic -Werror)
 
 # recursively get all src files
 RECURSE_FILES(cpp_file_list ${SOURCE_DIR}/*.cpp)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,37 @@
 # LibMainLoader
 
-Updated libmain part from https://github.com/sc2ad/QuestLoader
+Acts as a proxy `libmain.so` for Unity code injection via il2cpp on Android.
+
+Specifically stubs out: `JNI_OnLoad`, `JNI_OnUnload`
+
+## Building
+
+1. Make `ndkpath.txt` point to your NDK install of at least r25.
+1. Run `build.ps1`, which will configure CMake for you, and make a `build` directory, then will execute `ninja -C build` on that directory.
+
+To adjust any build flags, edit `CMakeLists.txt` directly, or forward the args through the command line.
+
+To build with decreased codesize (although not substantially), define `NO_EXCESS_LOGGING`.
+
+## Usage
+
+After building, which targets AArch64, replace the existing `libmain.so` in your unity application with the built `libmain.so`.
+
+Then, place a [modloader](#modloader) at: `/sdcard/ModData/<application id>/Modloader/*.so`.
+
+This binary will walk the
+
+## Modloader
+
+Ultimately a modloader must be `dlopen`-able without any specific dependencies. It should also be okay with being dlopened into the `GLOBAL` symbol lookup table. After that, it may _optionally_ define the following (`extern C`) functions, which will be called at various points during the loading process:
+
+| Signature | Call point |
+| --------- | ---------- |
+| `void modloader_preload(JNIEnv* env, char const* appId, char const* modloaderPath, char const* modloaderSourcePath, char const* filesDir, char const* externalDir) noexcept` | Called immediately after dlopen of the modloader. Forwards parameters that may be useful (largely to avoid duplicate JNI calls). |
+| `void modloader_load(JNIEnv* env, char const* soDir) noexcept` | Called after the `JavaVM` is found as part of the main loading process, via `JNI_OnLoad`. |
+| `void modloader_accept_unity_handle(JNIEnv* env, void* unityHandle) noexcept` | Called after `libunity.so` is dlopened, but before Unity's `JNI_OnLoad` is called. |
+| `void modloader_unload(JavaVM* vm) noexcept` | Called when `JNI_OnUnload` is called, after the `JavaVM` is obtained during teardown. |
+
+## Resources
+
+Updated libmain part from <https://github.com/sc2ad/QuestLoader>

--- a/include/_config.h
+++ b/include/_config.h
@@ -2,3 +2,9 @@
 
 #define MAIN_EXPORT __attribute__((visibility("default")))
 #define MAIN_LOCAL __attribute__((visibility("hidden")))
+
+// Helper defines for reducing codesize
+#ifdef NO_EXCESS_LOGGING
+#define NO_SPECIFIC_FAIL_LOGS
+#define NO_STAT_DUMPS
+#endif

--- a/include/_config.h
+++ b/include/_config.h
@@ -1,0 +1,4 @@
+#pragma once
+
+#define MAIN_EXPORT __attribute__((visibility("default")))
+#define MAIN_LOCAL __attribute__((visibility("hidden")))

--- a/include/fileutils.hpp
+++ b/include/fileutils.hpp
@@ -2,6 +2,7 @@
 
 #include <jni.h>
 
+#include <cstddef>
 #include <filesystem>
 #include <optional>
 #include <string>
@@ -11,13 +12,23 @@
 namespace fileutils {
 
 struct MAIN_LOCAL path_container {
+  std::filesystem::path modloaderSearchPath;
   std::filesystem::path filesDir;
   std::filesystem::path externalDir;
 };
 
-MAIN_LOCAL std::optional<path_container> getDirs(JNIEnv* env);
+MAIN_LOCAL std::optional<path_container> getDirs(JNIEnv* env, std::string_view application_id);
 MAIN_LOCAL std::optional<std::string> getApplicationId();
-MAIN_LOCAL bool ensurePerms(JNIEnv* env, jobject activity);
+MAIN_LOCAL bool ensurePerms(JNIEnv* env, jobject activity, std::string_view application_id);
 MAIN_LOCAL jobject getActivityFromUnityPlayer(JNIEnv* env);
+
+namespace literals {
+
+// To facilitate easier combination
+MAIN_LOCAL inline std::filesystem::path operator""_fp(const char* p, [[maybe_unused]] std::size_t sz) {
+  return std::filesystem::path(p);
+}
+
+}  // namespace literals
 
 }  // namespace fileutils

--- a/include/fileutils.hpp
+++ b/include/fileutils.hpp
@@ -7,7 +7,12 @@
 
 namespace fileutils {
 
-    std::optional<std::filesystem::path> getFilesDir(JNIEnv* env);
+    struct path_container {
+        std::filesystem::path filesDir;
+        std::filesystem::path externalDir;
+    };
+
+    std::optional<path_container> getDirs(JNIEnv* env);
     std::optional<std::string> getApplicationId();
 
 }

--- a/include/fileutils.hpp
+++ b/include/fileutils.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "_config.h"
 #include <jni.h>
 #include <string>
 #include <optional>
@@ -7,12 +8,14 @@
 
 namespace fileutils {
 
-    struct path_container {
+    struct MAIN_LOCAL path_container {
         std::filesystem::path filesDir;
         std::filesystem::path externalDir;
     };
 
-    std::optional<path_container> getDirs(JNIEnv* env);
-    std::optional<std::string> getApplicationId();
+    MAIN_LOCAL std::optional<path_container> getDirs(JNIEnv* env);
+    MAIN_LOCAL std::optional<std::string> getApplicationId();
+    MAIN_LOCAL bool ensurePerms(JNIEnv* env, jobject activity);
+    MAIN_LOCAL jobject getActivityFromUnityPlayer(JNIEnv *env);
 
 }

--- a/include/fileutils.hpp
+++ b/include/fileutils.hpp
@@ -1,21 +1,23 @@
 #pragma once
 
-#include "_config.h"
 #include <jni.h>
-#include <string>
-#include <optional>
+
 #include <filesystem>
+#include <optional>
+#include <string>
+
+#include "_config.h"
 
 namespace fileutils {
 
-    struct MAIN_LOCAL path_container {
-        std::filesystem::path filesDir;
-        std::filesystem::path externalDir;
-    };
+struct MAIN_LOCAL path_container {
+  std::filesystem::path filesDir;
+  std::filesystem::path externalDir;
+};
 
-    MAIN_LOCAL std::optional<path_container> getDirs(JNIEnv* env);
-    MAIN_LOCAL std::optional<std::string> getApplicationId();
-    MAIN_LOCAL bool ensurePerms(JNIEnv* env, jobject activity);
-    MAIN_LOCAL jobject getActivityFromUnityPlayer(JNIEnv *env);
+MAIN_LOCAL std::optional<path_container> getDirs(JNIEnv* env);
+MAIN_LOCAL std::optional<std::string> getApplicationId();
+MAIN_LOCAL bool ensurePerms(JNIEnv* env, jobject activity);
+MAIN_LOCAL jobject getActivityFromUnityPlayer(JNIEnv* env);
 
-}
+}  // namespace fileutils

--- a/include/jni.hpp
+++ b/include/jni.hpp
@@ -1,20 +1,22 @@
 #pragma once
-#include "_config.h"
 #include <jni.h>
+
 #include <string_view>
+
+#include "_config.h"
 
 namespace jni {
 
-    // For sv literal
-    using namespace std::string_view_literals;
+// For sv literal
+using namespace std::string_view_literals;
 
-    constexpr auto unityName = "libunity.so"sv;
-    MAIN_LOCAL extern void* unityHandle;
+constexpr auto unityName = "libunity.so"sv;
+MAIN_LOCAL extern void* unityHandle;
 
-    using JNI_OnLoad_t = jint(JavaVM*, void*);
-    using JNI_OnUnload_t = jint(JavaVM*, void*);
+using JNI_OnLoad_t = jint(JavaVM*, void*);
+using JNI_OnUnload_t = jint(JavaVM*, void*);
 
-    MAIN_LOCAL jboolean load(JNIEnv* env, jobject klass, jstring str) noexcept;
-    MAIN_LOCAL jboolean unload(JNIEnv* env, jobject klass) noexcept;
+MAIN_LOCAL jboolean load(JNIEnv* env, jobject klass, jstring str) noexcept;
+MAIN_LOCAL jboolean unload(JNIEnv* env, jobject klass) noexcept;
 
-}
+}  // namespace jni

--- a/include/jni.hpp
+++ b/include/jni.hpp
@@ -4,7 +4,10 @@
 
 namespace jni {
 
-    constexpr const std::string_view unityName = "libunity.so";
+    // For sv literal
+    using namespace std::string_view_literals;
+
+    constexpr auto unityName = "libunity.so"sv;
     extern void* unityHandle;
 
     using JNI_OnLoad_t = jint(JavaVM*, void*);

--- a/include/jni.hpp
+++ b/include/jni.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "_config.h"
 #include <jni.h>
 #include <string_view>
 
@@ -8,12 +9,12 @@ namespace jni {
     using namespace std::string_view_literals;
 
     constexpr auto unityName = "libunity.so"sv;
-    extern void* unityHandle;
+    MAIN_LOCAL extern void* unityHandle;
 
     using JNI_OnLoad_t = jint(JavaVM*, void*);
     using JNI_OnUnload_t = jint(JavaVM*, void*);
 
-    jboolean load(JNIEnv* env, jobject klass, jstring str) noexcept;
-    jboolean unload(JNIEnv* env, jobject klass) noexcept;
+    MAIN_LOCAL jboolean load(JNIEnv* env, jobject klass, jstring str) noexcept;
+    MAIN_LOCAL jboolean unload(JNIEnv* env, jobject klass) noexcept;
 
 }

--- a/include/log.hpp
+++ b/include/log.hpp
@@ -7,4 +7,3 @@
 #define LOG_INFO(...) __android_log_print(ANDROID_LOG_INFO, "libmain - patched", __VA_ARGS__)
 #define LOG_WARN(...) __android_log_print(ANDROID_LOG_WARN, "libmain - patched", __VA_ARGS__)
 #define LOG_ERROR(...) __android_log_print(ANDROID_LOG_ERROR, "libmain - patched", __VA_ARGS__)
-

--- a/include/main.hpp
+++ b/include/main.hpp
@@ -1,1 +1,0 @@
-#pragma once

--- a/include/modloader.hpp
+++ b/include/modloader.hpp
@@ -1,35 +1,39 @@
 #pragma once
 
-#include "_config.h"
 #include <jni.h>
-#include <string_view>
+
 #include <filesystem>
+#include <string_view>
+
+#include "_config.h"
+
 
 namespace modloader {
 
-    // For sv literal
-    using namespace std::string_view_literals;
+// For sv literal
+using namespace std::string_view_literals;
 
-    MAIN_LOCAL constexpr auto modloaderName = "libmodloader.so"sv;
-    MAIN_LOCAL extern void* modloaderHandle;
-    
-    /// @brief Called after modloader gets dlopened in JNI_OnLoad.
-    /// The lifetimes of pointers are within this call only and should be copied.
-    using preload_t = void(JNIEnv* env, char const* appId, char const* modloaderPath, char const* filesDir, char const* externalDir) noexcept;
-    MAIN_LOCAL constexpr auto preloadName = "modloader_preload"sv;
-    /// @brief Called before unity gets dlopened
-    using load_t = void(JNIEnv* env, char const* soDir) noexcept;
-    MAIN_LOCAL constexpr auto loadName = "modloader_load"sv;
-    /// @brief Called after unity gets dlopened
-    using accept_unity_handle_t = void(JNIEnv* env, void* unityHandle) noexcept;
-    MAIN_LOCAL constexpr auto accept_unity_handleName = "modloader_accept_unity_handle"sv;
-    /// @brief Called during teardown (sometimes)
-    using unload_t = void(JavaVM* vm) noexcept;
-    MAIN_LOCAL constexpr auto unloadName = "modloader_unload"sv;
+MAIN_LOCAL constexpr auto modloaderName = "libmodloader.so"sv;
+MAIN_LOCAL extern void* modloaderHandle;
 
-    MAIN_LOCAL void preload(JNIEnv* env) noexcept;
-    MAIN_LOCAL void load(JNIEnv* env, char const* soDir) noexcept;
-    MAIN_LOCAL void accept_unity_handle(JNIEnv* env, void* unityHandle) noexcept;
-    MAIN_LOCAL void unload(JavaVM* vm) noexcept;
+/// @brief Called after modloader gets dlopened in JNI_OnLoad.
+/// The lifetimes of pointers are within this call only and should be copied.
+using preload_t = void(JNIEnv* env, char const* appId, char const* modloaderPath, char const* filesDir,
+                       char const* externalDir) noexcept;
+MAIN_LOCAL constexpr auto preloadName = "modloader_preload"sv;
+/// @brief Called before unity gets dlopened
+using load_t = void(JNIEnv* env, char const* soDir) noexcept;
+MAIN_LOCAL constexpr auto loadName = "modloader_load"sv;
+/// @brief Called after unity gets dlopened
+using accept_unity_handle_t = void(JNIEnv* env, void* unityHandle) noexcept;
+MAIN_LOCAL constexpr auto accept_unity_handleName = "modloader_accept_unity_handle"sv;
+/// @brief Called during teardown (sometimes)
+using unload_t = void(JavaVM* vm) noexcept;
+MAIN_LOCAL constexpr auto unloadName = "modloader_unload"sv;
 
-}
+MAIN_LOCAL void preload(JNIEnv* env) noexcept;
+MAIN_LOCAL void load(JNIEnv* env, char const* soDir) noexcept;
+MAIN_LOCAL void accept_unity_handle(JNIEnv* env, void* unityHandle) noexcept;
+MAIN_LOCAL void unload(JavaVM* vm) noexcept;
+
+}  // namespace modloader

--- a/include/modloader.hpp
+++ b/include/modloader.hpp
@@ -6,16 +6,25 @@
 
 namespace modloader {
 
-    constexpr const std::string_view modloaderName = "libmodloader.so";
+    // For sv literal
+    using namespace std::string_view_literals;
+
+    constexpr auto modloaderName = "libmodloader.so"sv;
     extern void* modloaderHandle;
     
-    /*Called after modloader gets dlopened in JNI_OnLoad*/
-    using preload_t = void(JNIEnv* env, const char* path) noexcept;
-    /*Called before unity gets dlopened*/
+    /// @brief Called after modloader gets dlopened in JNI_OnLoad.
+    /// The lifetimes of pointers are within this call only and should be copied.
+    using preload_t = void(JNIEnv* env, char const* modloaderPath, char const* filesDir, char const* externalDir) noexcept;
+    constexpr auto preloadName = "modloader_preload"sv;
+    /// @brief Called before unity gets dlopened
     using load_t = void(JNIEnv* env) noexcept;
-    /*Called after unity gets dlopened*/
+    constexpr auto loadName = "modloader_load"sv;
+    /// @brief Called after unity gets dlopened
     using accept_unity_handle_t = void(JNIEnv* env, void* unityHandle) noexcept;
+    constexpr auto accept_unity_handleName = "modloader_accept_unity_handle"sv;
+    /// @brief Called during teardown (sometimes)
     using unload_t = void(JNIEnv* env) noexcept;
+    constexpr auto unloadName = "modloader_unload"sv;
 
     void preload(JNIEnv* env) noexcept;
     void load(JNIEnv* env) noexcept;

--- a/include/modloader.hpp
+++ b/include/modloader.hpp
@@ -7,19 +7,17 @@
 
 #include "_config.h"
 
-
 namespace modloader {
 
 // For sv literal
 using namespace std::string_view_literals;
 
-MAIN_LOCAL constexpr auto modloaderName = "libmodloader.so"sv;
 MAIN_LOCAL extern void* modloaderHandle;
 
 /// @brief Called after modloader gets dlopened in JNI_OnLoad.
 /// The lifetimes of pointers are within this call only and should be copied.
-using preload_t = void(JNIEnv* env, char const* appId, char const* modloaderPath, char const* filesDir,
-                       char const* externalDir) noexcept;
+using preload_t = void(JNIEnv* env, char const* appId, char const* modloaderPath, char const* modloaderSourcePath,
+                       char const* filesDir, char const* externalDir) noexcept;
 MAIN_LOCAL constexpr auto preloadName = "modloader_preload"sv;
 /// @brief Called before unity gets dlopened
 using load_t = void(JNIEnv* env, char const* soDir) noexcept;

--- a/include/modloader.hpp
+++ b/include/modloader.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "_config.h"
 #include <jni.h>
 #include <string_view>
 #include <filesystem>
@@ -9,26 +10,26 @@ namespace modloader {
     // For sv literal
     using namespace std::string_view_literals;
 
-    constexpr auto modloaderName = "libmodloader.so"sv;
-    extern void* modloaderHandle;
+    MAIN_LOCAL constexpr auto modloaderName = "libmodloader.so"sv;
+    MAIN_LOCAL extern void* modloaderHandle;
     
     /// @brief Called after modloader gets dlopened in JNI_OnLoad.
     /// The lifetimes of pointers are within this call only and should be copied.
-    using preload_t = void(JNIEnv* env, char const* modloaderPath, char const* filesDir, char const* externalDir) noexcept;
-    constexpr auto preloadName = "modloader_preload"sv;
+    using preload_t = void(JNIEnv* env, char const* appId, char const* modloaderPath, char const* filesDir, char const* externalDir) noexcept;
+    MAIN_LOCAL constexpr auto preloadName = "modloader_preload"sv;
     /// @brief Called before unity gets dlopened
-    using load_t = void(JNIEnv* env) noexcept;
-    constexpr auto loadName = "modloader_load"sv;
+    using load_t = void(JNIEnv* env, char const* soDir) noexcept;
+    MAIN_LOCAL constexpr auto loadName = "modloader_load"sv;
     /// @brief Called after unity gets dlopened
     using accept_unity_handle_t = void(JNIEnv* env, void* unityHandle) noexcept;
-    constexpr auto accept_unity_handleName = "modloader_accept_unity_handle"sv;
+    MAIN_LOCAL constexpr auto accept_unity_handleName = "modloader_accept_unity_handle"sv;
     /// @brief Called during teardown (sometimes)
-    using unload_t = void(JNIEnv* env) noexcept;
-    constexpr auto unloadName = "modloader_unload"sv;
+    using unload_t = void(JavaVM* vm) noexcept;
+    MAIN_LOCAL constexpr auto unloadName = "modloader_unload"sv;
 
-    void preload(JNIEnv* env) noexcept;
-    void load(JNIEnv* env) noexcept;
-    void accept_unity_handle(JNIEnv* env, void* unityHandle) noexcept;
-    void unload(JNIEnv* env) noexcept;
+    MAIN_LOCAL void preload(JNIEnv* env) noexcept;
+    MAIN_LOCAL void load(JNIEnv* env, char const* soDir) noexcept;
+    MAIN_LOCAL void accept_unity_handle(JNIEnv* env, void* unityHandle) noexcept;
+    MAIN_LOCAL void unload(JavaVM* vm) noexcept;
 
 }

--- a/src/fileutils.cpp
+++ b/src/fileutils.cpp
@@ -66,7 +66,7 @@ std::optional<fileutils::path_container> fileutils::getDirs(JNIEnv* env) {
     auto contextClass = NULLOPT_UNLESS(env->FindClass("android/content/Context"), "Failed to find android.context.Context!");
     auto getApplicationMethod = NULLOPT_UNLESS(env->GetMethodID(activityThreadClass, "getApplication", "()Landroid/app/Application;"), "Failed to find Application.getApplication");
     auto filesDirMethod = NULLOPT_UNLESS(env->GetMethodID(contextClass, "getFilesDir", "()Ljava/io/File;"), "Failed to find Context.getFilesDir()");
-    auto externalDirMethod = NULLOPT_UNLESS(env->GetMethodID(contextClass, "getExternalFilesDir", "(Ljava/lang/String)Ljava/io/File;"), "Failed to find Context.getExternalFilesDir(String)");
+    auto externalDirMethod = NULLOPT_UNLESS(env->GetMethodID(contextClass, "getExternalFilesDir", "(Ljava/lang/String;)Ljava/io/File;"), "Failed to find Context.getExternalFilesDir(String)");
     auto fileClass = NULLOPT_UNLESS(env->FindClass("java/io/File"), "Failed to find java.io.File!");
     auto absDirMethod = NULLOPT_UNLESS(env->GetMethodID(fileClass, "getAbsolutePath", "()Ljava/lang/String;"), "Failed to find File.getAbsolutePath()");
 

--- a/src/fileutils.cpp
+++ b/src/fileutils.cpp
@@ -4,6 +4,9 @@
 #include <jni.h>
 
 #include <cstring>
+#include <filesystem>
+#include <string_view>
+#include <thread>
 
 #include "log.hpp"
 
@@ -21,98 +24,118 @@ char* trimWhitespace(char* str) {
   return str;
 }
 
-jobject getActivityFromUnityPlayerInternal(JNIEnv* env) {
-  jclass clazz = env->FindClass("com/unity3d/player/UnityPlayer");
-  if (clazz == NULL) return nullptr;
-  jfieldID actField = env->GetStaticFieldID(clazz, "currentActivity", "Landroid/app/Activity;");
-  if (actField == NULL) return nullptr;
-  return env->GetStaticObjectField(clazz, actField);
-}
+#define STRIFY(...) STRIFY2(__VA_ARGS__)
+#define STRIFY2(...) #__VA_ARGS__
 
-bool ensurePermsInternal(JNIEnv* env, jobject activity) {
-  // We only need the read permission here, since we need to copy over the
-  // modloader so we can open it. That said, we should request for MANAGE
-  // because it gives us a bit more power (and the modloader will want it
-  // anyways)
-  jclass clazz = env->FindClass("com/unity3d/player/UnityPlayerActivity");
-  if (clazz == nullptr) return false;
-  jmethodID checkSelfPermission = env->GetMethodID(clazz, "checkSelfPermission", "(Ljava/lang/String;)I");
-  if (checkSelfPermission == nullptr) return false;
-  const jstring perm = env->NewStringUTF("android.permission.MANAGE_EXTERNAL_STORAGE");
-  jint hasPerm = env->CallIntMethod(activity, checkSelfPermission, perm);
-  LOG_DEBUG("checkSelfPermission(MANAGE_EXTERNAL_STORAGE) returned: %i", hasPerm);
-  if (hasPerm != 0) {
-    jmethodID requestPermissions = env->GetMethodID(clazz, "requestPermissions", "([Ljava/lang/String;I)V");
-    if (requestPermissions == nullptr) return false;
-    jclass stringClass = env->FindClass("java/lang/String");
-    jobjectArray arr = env->NewObjectArray(1, stringClass, perm);
-    constexpr jint requestCode = 21326;  // arbitrary
-    LOG_INFO("Calling requestPermissions!");
-    env->CallVoidMethod(activity, requestPermissions, arr, requestCode);
+#ifndef NO_SPECIFIC_FAIL_LOGS
+#define ERR_CHECK(val, ...)                                                \
+  auto val = __VA_ARGS__;                                                  \
+  if (val == nullptr) {                                                    \
+    LOG_ERROR("Failed: " __FILE__ ":" STRIFY(__LINE__) ": " #__VA_ARGS__); \
+    return {};                                                             \
+  }
+#else
+#define ERR_CHECK(val, ...)                              \
+  auto val = __VA_ARGS__;                                \
+  if (val == nullptr) {                                  \
+    LOG_ERROR("Failed: " __FILE__ ":" STRIFY(__LINE__)); \
+    return {};                                           \
+  }
+#endif
+
+jobject getActivityFromUnityPlayerInternal(JNIEnv* env) {
+  ERR_CHECK(clazz, env->FindClass("com/unity3d/player/UnityPlayer"));
+  ERR_CHECK(actField, env->GetStaticFieldID(clazz, "currentActivity", "Landroid/app/Activity;"));
+  ERR_CHECK(result, env->GetStaticObjectField(clazz, actField));
+  return result;
+}
+bool ensurePermsWithAppId(JNIEnv* env, jobject activity, std::string_view application_id) {
+  ERR_CHECK(clazz, env->FindClass("com/unity3d/player/UnityPlayerActivity"));
+  ERR_CHECK(intentClass, env->FindClass("android/content/Intent"));
+  ERR_CHECK(intentCtorID, env->GetMethodID(intentClass, "<init>", "(Ljava/lang/String;Landroid/net/Uri;)V"));
+  ERR_CHECK(startActivity, env->GetMethodID(clazz, "startActivity", "(Landroid/content/Intent;)V"));
+  ERR_CHECK(uriClass, env->FindClass("android/net/Uri"));
+  ERR_CHECK(uriParse, env->GetStaticMethodID(uriClass, "parse", "(Ljava/lang/String;)Landroid/net/Uri;"));
+  ERR_CHECK(envClass, env->FindClass("android/os/Environment"));
+  ERR_CHECK(isExternalMethod, env->GetStaticMethodID(envClass, "isExternalStorageManager", "()Z"));
+
+  using namespace std::chrono_literals;
+  // We loop the attempt to display permissions
+  // The goal here is to avoid getting in too early
+  // However, we don't really know what will happen:
+  // 1. If a user does not select anything for the duration of the delay
+  // 2. If the delay is too excessive and causes the app to exit out from watchdog
+  constexpr static auto kNumTries = 3;
+  constexpr static auto kDelay = 5000ms;
+
+  for (int i = 0; i < kNumTries; i++) {
+    auto result = env->CallStaticBooleanMethod(envClass, isExternalMethod);
+    if (env->ExceptionCheck()) {
+      LOG_ERROR("Failed: to call Environment.getIsExternalStorageManager()");
+      return false;
+    }
+    LOG_INFO("Fetch of isExternalStorageManager(): %d", result);
+    // If we already granted permissions, good to go
+    if (result) return true;
+    // Otherwise, need to display
+    LOG_DEBUG("Attempt to show intent for MANAGE APP ALL FILES ACCESS PERMISSION:");
+    // We pay the penalty of reconstructing these every iteration, as we don't expect to need to do so.
+    const jstring actionName = env->NewStringUTF("android.settings.MANAGE_APP_ALL_FILES_ACCESS_PERMISSION");
+    const jstring packageName = env->NewStringUTF((std::string("package:") + application_id.data()).c_str());
+    ERR_CHECK(uri, env->CallStaticObjectMethod(uriClass, uriParse, packageName));
+    ERR_CHECK(intent, env->NewObject(intentClass, intentCtorID, actionName, uri));
+    // Attempt to start the activity to show the correct settings display
+    // and hope that this is ok to show in excess?
+    env->CallVoidMethod(activity, startActivity, intent);
     if (env->ExceptionCheck()) return false;
+    // At this point, sleep the thread to avoid acting too fast
+    std::this_thread::sleep_for(kDelay);
   }
   return true;
 }
 
 }  // namespace
 
-#define NULLOPT_UNLESS(expr, ...) \
-  ({                              \
-    auto&& __tmp = (expr);        \
-    if (!__tmp) {                 \
-      LOG_ERROR(__VA_ARGS__);     \
-      return std::nullopt;        \
-    }                             \
-    __tmp;                        \
-  })
+std::optional<fileutils::path_container> fileutils::getDirs(JNIEnv* env, std::string_view application_id) {
+  ERR_CHECK(activityThreadClass, env->FindClass("android/app/ActivityThread"));
+  ERR_CHECK(currentActivityThreadMethod,
+            env->GetStaticMethodID(activityThreadClass, "currentActivityThread", "()Landroid/app/ActivityThread;"));
+  ERR_CHECK(contextClass, env->FindClass("android/content/Context"));
+  ERR_CHECK(getApplicationMethod,
+            env->GetMethodID(activityThreadClass, "getApplication", "()Landroid/app/Application;"));
+  ERR_CHECK(filesDirMethod, env->GetMethodID(contextClass, "getFilesDir", "()Ljava/io/File;"));
+  ERR_CHECK(externalDirMethod,
+            env->GetMethodID(contextClass, "getExternalFilesDir", "(Ljava/lang/String;)Ljava/io/File;"));
+  ERR_CHECK(fileClass, env->FindClass("java/io/File"));
+  ERR_CHECK(absDirMethod, env->GetMethodID(fileClass, "getAbsolutePath", "()Ljava/lang/String;"));
 
-std::optional<fileutils::path_container> fileutils::getDirs(JNIEnv* env) {
-  auto activityThreadClass =
-      NULLOPT_UNLESS(env->FindClass("android/app/ActivityThread"), "Failed to find android.app.ActivityThread!");
-  auto currentActivityThreadMethod = NULLOPT_UNLESS(
-      env->GetStaticMethodID(activityThreadClass, "currentActivityThread", "()Landroid/app/ActivityThread;"),
-      "Failed to find ActivityThread.currentActivityThread");
-  auto contextClass =
-      NULLOPT_UNLESS(env->FindClass("android/content/Context"), "Failed to find android.context.Context!");
-  auto getApplicationMethod =
-      NULLOPT_UNLESS(env->GetMethodID(activityThreadClass, "getApplication", "()Landroid/app/Application;"),
-                     "Failed to find Application.getApplication");
-  auto filesDirMethod = NULLOPT_UNLESS(env->GetMethodID(contextClass, "getFilesDir", "()Ljava/io/File;"),
-                                       "Failed to find Context.getFilesDir()");
-  auto externalDirMethod =
-      NULLOPT_UNLESS(env->GetMethodID(contextClass, "getExternalFilesDir", "(Ljava/lang/String;)Ljava/io/File;"),
-                     "Failed to find Context.getExternalFilesDir(String)");
-  auto fileClass = NULLOPT_UNLESS(env->FindClass("java/io/File"), "Failed to find java.io.File!");
-  auto absDirMethod = NULLOPT_UNLESS(env->GetMethodID(fileClass, "getAbsolutePath", "()Ljava/lang/String;"),
-                                     "Failed to find File.getAbsolutePath()");
+  using namespace fileutils::literals;
+  // Construct the path to the modloader here, as there's no point in attempting to load if we can't get the other dirs
+  // as well
+  fileutils::path_container result{.modloaderSearchPath =
+                                       std::filesystem::absolute("/sdcard/ModData"_fp / application_id / "Modloader")};
 
-  fileutils::path_container result{};
-
-  auto at = NULLOPT_UNLESS(env->CallStaticObjectMethod(activityThreadClass, currentActivityThreadMethod),
-                           "Returned result from currentActivityThread is null!");
-  auto context =
-      NULLOPT_UNLESS(env->CallObjectMethod(at, getApplicationMethod), "Returned result from getApplication is null!");
-  auto filesDir =
-      NULLOPT_UNLESS(env->CallObjectMethod(context, filesDirMethod), "Returned result from getFilesDir is null!");
+  ERR_CHECK(at, env->CallStaticObjectMethod(activityThreadClass, currentActivityThreadMethod));
+  ERR_CHECK(context, env->CallObjectMethod(at, getApplicationMethod));
+  ERR_CHECK(filesDir, env->CallObjectMethod(context, filesDirMethod));
   {
-    auto str = reinterpret_cast<jstring>(
-        NULLOPT_UNLESS(env->CallObjectMethod(filesDir, absDirMethod), "Returned result from getAbsolutePath is null!"));
+    ERR_CHECK(str, reinterpret_cast<jstring>(env->CallObjectMethod(filesDir, absDirMethod)));
     auto chars = env->GetStringUTFChars(str, nullptr);
     result.filesDir = chars;
     env->ReleaseStringUTFChars(str, chars);
   }
 
-  auto externalDir = NULLOPT_UNLESS(env->CallObjectMethod(context, externalDirMethod, static_cast<jstring>(nullptr)),
-                                    "Returned result from getExternalFilesDir is null!");
+  ERR_CHECK(externalDir, env->CallObjectMethod(context, externalDirMethod, static_cast<jstring>(nullptr)));
   {
-    auto str = reinterpret_cast<jstring>(NULLOPT_UNLESS(env->CallObjectMethod(externalDir, absDirMethod),
-                                                        "Returned result from getAbsolutePath is null!"));
+    ERR_CHECK(str, reinterpret_cast<jstring>(env->CallObjectMethod(externalDir, absDirMethod)));
     auto chars = env->GetStringUTFChars(str, nullptr);
     result.externalDir = chars;
     env->ReleaseStringUTFChars(str, chars);
   }
   return result;
 }
+
+#undef ERR_CHECK
 
 std::optional<std::string> fileutils::getApplicationId() {
   FILE* cmdline = fopen("/proc/self/cmdline", "r");
@@ -137,8 +160,10 @@ jobject fileutils::getActivityFromUnityPlayer(JNIEnv* env) {
   return activity;
 }
 
-bool fileutils::ensurePerms(JNIEnv* env, jobject activity) {
-  if (ensurePermsInternal(env, activity)) return true;
+bool fileutils::ensurePerms(JNIEnv* env, jobject activity, std::string_view application_id) {
+  // TODO: The correct thing to do would be to listen to the completion event and resume modloading when that happens.
+  // Instead, we actually sleep the thread, which is potentially problematic.
+  if (ensurePermsWithAppId(env, activity, application_id)) return true;
 
   if (env->ExceptionCheck()) env->ExceptionDescribe();
   LOG_ERROR("libmain.ensurePerms failed! See 'System.err' tag.");

--- a/src/fileutils.cpp
+++ b/src/fileutils.cpp
@@ -11,24 +11,36 @@ auto&& __tmp = (expr); \
 if (!__tmp) {LOG_ERROR(__VA_ARGS__); return std::nullopt;} \
 __tmp; })
 
-std::optional<fs::path> fileutils::getFilesDir(JNIEnv* env) {
+std::optional<fileutils::path_container> fileutils::getDirs(JNIEnv* env) {
     auto activityThreadClass = NULLOPT_UNLESS(env->FindClass("android/app/ActivityThread"), "Failed to find android.app.ActivityThread!");
     auto currentActivityThreadMethod = NULLOPT_UNLESS(env->GetStaticMethodID(activityThreadClass, "currentActivityThread", "()Landroid/app/ActivityThread;"), "Failed to find ActivityThread.currentActivityThread");
     auto contextClass = NULLOPT_UNLESS(env->FindClass("android/content/Context"), "Failed to find android.context.Context!");
     auto getApplicationMethod = NULLOPT_UNLESS(env->GetMethodID(activityThreadClass, "getApplication", "()Landroid/app/Application;"), "Failed to find Application.getApplication");
-    auto filesDirMethod = NULLOPT_UNLESS(env->GetMethodID(contextClass, "getFilesDir", "()Ljava/io/File;"), "Failed to find Context.getFilesDir()!");
+    auto filesDirMethod = NULLOPT_UNLESS(env->GetMethodID(contextClass, "getFilesDir", "()Ljava/io/File;"), "Failed to find Context.getFilesDir()");
+    auto externalDirMethod = NULLOPT_UNLESS(env->GetMethodID(contextClass, "getExternalFilesDir", "(Ljava/lang/String)Ljava/io/File;"), "Failed to find Context.getExternalFilesDir(String)");
     auto fileClass = NULLOPT_UNLESS(env->FindClass("java/io/File"), "Failed to find java.io.File!");
-    auto absDirMethod = NULLOPT_UNLESS(env->GetMethodID(fileClass, "getAbsolutePath", "()Ljava/lang/String;"), "Failed to find File.getAbsolutePath()!");
+    auto absDirMethod = NULLOPT_UNLESS(env->GetMethodID(fileClass, "getAbsolutePath", "()Ljava/lang/String;"), "Failed to find File.getAbsolutePath()");
+
+    fileutils::path_container result{};
 
     auto at = NULLOPT_UNLESS(env->CallStaticObjectMethod(activityThreadClass, currentActivityThreadMethod), "Returned result from currentActivityThread is null!");
     auto context = NULLOPT_UNLESS(env->CallObjectMethod(at, getApplicationMethod), "Returned result from getApplication is null!");
-    auto file = NULLOPT_UNLESS(env->CallObjectMethod(context, filesDirMethod), "Returned result from getFilesDir is null!");
-    auto str = reinterpret_cast<jstring>(NULLOPT_UNLESS(env->CallObjectMethod(file, absDirMethod), "Returned result from getAbsolutePath is null!"));
-    
-    auto chars = env->GetStringUTFChars(str, nullptr);
-    fs::path path(chars);
-    env->ReleaseStringUTFChars(str, chars);
-    return path;
+    auto filesDir = NULLOPT_UNLESS(env->CallObjectMethod(context, filesDirMethod), "Returned result from getFilesDir is null!");
+    {
+        auto str = reinterpret_cast<jstring>(NULLOPT_UNLESS(env->CallObjectMethod(filesDir, absDirMethod), "Returned result from getAbsolutePath is null!"));
+        auto chars = env->GetStringUTFChars(str, nullptr);
+        result.filesDir = chars;
+        env->ReleaseStringUTFChars(str, chars);
+    }
+
+    auto externalDir = NULLOPT_UNLESS(env->CallObjectMethod(context, externalDirMethod, static_cast<jstring>(nullptr)), "Returned result from getExternalFilesDir is null!");
+    {
+        auto str = reinterpret_cast<jstring>(NULLOPT_UNLESS(env->CallObjectMethod(externalDir, absDirMethod), "Returned result from getAbsolutePath is null!"));
+        auto chars = env->GetStringUTFChars(str, nullptr);
+        result.externalDir = chars;
+        env->ReleaseStringUTFChars(str, chars);
+    }
+    return result;
 }
 
 char *trimWhitespace(char *str) {
@@ -57,3 +69,4 @@ std::optional<std::string> fileutils::getApplicationId() {
     }
     return std::nullopt;
 }
+

--- a/src/fileutils.cpp
+++ b/src/fileutils.cpp
@@ -1,125 +1,147 @@
-#include "log.hpp"
 #include "fileutils.hpp"
 
-#include <jni.h>
 #include <ctype.h>
+#include <jni.h>
+
 #include <cstring>
 
-namespace fs = std::filesystem;
+#include "log.hpp"
 
 namespace {
-char *trimWhitespace(char *str) {
-    char *end;
-    while(isspace((unsigned char)*str)) str++;
-    if(*str == 0)
-        return str;
+char* trimWhitespace(char* str) {
+  char* end;
+  while (isspace((unsigned char)*str)) str++;
+  if (*str == 0) return str;
 
-    end = str + strlen(str) - 1;
-    while(end > str && isspace((unsigned char)*end)) end--;
+  end = str + strlen(str) - 1;
+  while (end > str && isspace((unsigned char)*end)) end--;
 
-    end[1] = '\0';
+  end[1] = '\0';
 
-    return str;
+  return str;
 }
 
-jobject getActivityFromUnityPlayerInternal(JNIEnv *env) {
-    jclass clazz = env->FindClass("com/unity3d/player/UnityPlayer");
-    if (clazz == NULL) return nullptr;
-    jfieldID actField = env->GetStaticFieldID(clazz, "currentActivity", "Landroid/app/Activity;");
-    if (actField == NULL) return nullptr;
-    return env->GetStaticObjectField(clazz, actField);
+jobject getActivityFromUnityPlayerInternal(JNIEnv* env) {
+  jclass clazz = env->FindClass("com/unity3d/player/UnityPlayer");
+  if (clazz == NULL) return nullptr;
+  jfieldID actField = env->GetStaticFieldID(clazz, "currentActivity", "Landroid/app/Activity;");
+  if (actField == NULL) return nullptr;
+  return env->GetStaticObjectField(clazz, actField);
 }
 
 bool ensurePermsInternal(JNIEnv* env, jobject activity) {
-    // We only need the read permission here, since we need to copy over the modloader so we can open it. 
-    // That said, we should request for MANAGE because it gives us a bit more power (and the modloader will want it anyways)
-    jclass clazz = env->FindClass("com/unity3d/player/UnityPlayerActivity");
-    if (clazz == nullptr) return false;
-    jmethodID checkSelfPermission = env->GetMethodID(clazz, "checkSelfPermission", "(Ljava/lang/String;)I");
-    if (checkSelfPermission == nullptr) return false;
-    const jstring perm = env->NewStringUTF("android.permission.MANAGE_EXTERNAL_STORAGE");
-    jint hasPerm = env->CallIntMethod(activity, checkSelfPermission, perm);
-    LOG_DEBUG("checkSelfPermission(MANAGE_EXTERNAL_STORAGE) returned: %i", hasPerm);
-    if (hasPerm != 0) {
-        jmethodID requestPermissions = env->GetMethodID(clazz, "requestPermissions", "([Ljava/lang/String;I)V");
-        if (requestPermissions == nullptr) return false;
-        jclass stringClass = env->FindClass("java/lang/String");
-        jobjectArray arr = env->NewObjectArray(1, stringClass, perm);
-        constexpr jint requestCode = 21326; // arbitrary
-        LOG_INFO("Calling requestPermissions!");
-        env->CallVoidMethod(activity, requestPermissions, arr, requestCode);
-        if (env->ExceptionCheck()) return false;
-    }
-    return true;
+  // We only need the read permission here, since we need to copy over the
+  // modloader so we can open it. That said, we should request for MANAGE
+  // because it gives us a bit more power (and the modloader will want it
+  // anyways)
+  jclass clazz = env->FindClass("com/unity3d/player/UnityPlayerActivity");
+  if (clazz == nullptr) return false;
+  jmethodID checkSelfPermission = env->GetMethodID(clazz, "checkSelfPermission", "(Ljava/lang/String;)I");
+  if (checkSelfPermission == nullptr) return false;
+  const jstring perm = env->NewStringUTF("android.permission.MANAGE_EXTERNAL_STORAGE");
+  jint hasPerm = env->CallIntMethod(activity, checkSelfPermission, perm);
+  LOG_DEBUG("checkSelfPermission(MANAGE_EXTERNAL_STORAGE) returned: %i", hasPerm);
+  if (hasPerm != 0) {
+    jmethodID requestPermissions = env->GetMethodID(clazz, "requestPermissions", "([Ljava/lang/String;I)V");
+    if (requestPermissions == nullptr) return false;
+    jclass stringClass = env->FindClass("java/lang/String");
+    jobjectArray arr = env->NewObjectArray(1, stringClass, perm);
+    constexpr jint requestCode = 21326;  // arbitrary
+    LOG_INFO("Calling requestPermissions!");
+    env->CallVoidMethod(activity, requestPermissions, arr, requestCode);
+    if (env->ExceptionCheck()) return false;
+  }
+  return true;
 }
 
-}
+}  // namespace
 
-#define NULLOPT_UNLESS(expr, ...) ({ \
-auto&& __tmp = (expr); \
-if (!__tmp) {LOG_ERROR(__VA_ARGS__); return std::nullopt;} \
-__tmp; })
+#define NULLOPT_UNLESS(expr, ...) \
+  ({                              \
+    auto&& __tmp = (expr);        \
+    if (!__tmp) {                 \
+      LOG_ERROR(__VA_ARGS__);     \
+      return std::nullopt;        \
+    }                             \
+    __tmp;                        \
+  })
 
 std::optional<fileutils::path_container> fileutils::getDirs(JNIEnv* env) {
-    auto activityThreadClass = NULLOPT_UNLESS(env->FindClass("android/app/ActivityThread"), "Failed to find android.app.ActivityThread!");
-    auto currentActivityThreadMethod = NULLOPT_UNLESS(env->GetStaticMethodID(activityThreadClass, "currentActivityThread", "()Landroid/app/ActivityThread;"), "Failed to find ActivityThread.currentActivityThread");
-    auto contextClass = NULLOPT_UNLESS(env->FindClass("android/content/Context"), "Failed to find android.context.Context!");
-    auto getApplicationMethod = NULLOPT_UNLESS(env->GetMethodID(activityThreadClass, "getApplication", "()Landroid/app/Application;"), "Failed to find Application.getApplication");
-    auto filesDirMethod = NULLOPT_UNLESS(env->GetMethodID(contextClass, "getFilesDir", "()Ljava/io/File;"), "Failed to find Context.getFilesDir()");
-    auto externalDirMethod = NULLOPT_UNLESS(env->GetMethodID(contextClass, "getExternalFilesDir", "(Ljava/lang/String;)Ljava/io/File;"), "Failed to find Context.getExternalFilesDir(String)");
-    auto fileClass = NULLOPT_UNLESS(env->FindClass("java/io/File"), "Failed to find java.io.File!");
-    auto absDirMethod = NULLOPT_UNLESS(env->GetMethodID(fileClass, "getAbsolutePath", "()Ljava/lang/String;"), "Failed to find File.getAbsolutePath()");
+  auto activityThreadClass =
+      NULLOPT_UNLESS(env->FindClass("android/app/ActivityThread"), "Failed to find android.app.ActivityThread!");
+  auto currentActivityThreadMethod = NULLOPT_UNLESS(
+      env->GetStaticMethodID(activityThreadClass, "currentActivityThread", "()Landroid/app/ActivityThread;"),
+      "Failed to find ActivityThread.currentActivityThread");
+  auto contextClass =
+      NULLOPT_UNLESS(env->FindClass("android/content/Context"), "Failed to find android.context.Context!");
+  auto getApplicationMethod =
+      NULLOPT_UNLESS(env->GetMethodID(activityThreadClass, "getApplication", "()Landroid/app/Application;"),
+                     "Failed to find Application.getApplication");
+  auto filesDirMethod = NULLOPT_UNLESS(env->GetMethodID(contextClass, "getFilesDir", "()Ljava/io/File;"),
+                                       "Failed to find Context.getFilesDir()");
+  auto externalDirMethod =
+      NULLOPT_UNLESS(env->GetMethodID(contextClass, "getExternalFilesDir", "(Ljava/lang/String;)Ljava/io/File;"),
+                     "Failed to find Context.getExternalFilesDir(String)");
+  auto fileClass = NULLOPT_UNLESS(env->FindClass("java/io/File"), "Failed to find java.io.File!");
+  auto absDirMethod = NULLOPT_UNLESS(env->GetMethodID(fileClass, "getAbsolutePath", "()Ljava/lang/String;"),
+                                     "Failed to find File.getAbsolutePath()");
 
-    fileutils::path_container result{};
+  fileutils::path_container result{};
 
-    auto at = NULLOPT_UNLESS(env->CallStaticObjectMethod(activityThreadClass, currentActivityThreadMethod), "Returned result from currentActivityThread is null!");
-    auto context = NULLOPT_UNLESS(env->CallObjectMethod(at, getApplicationMethod), "Returned result from getApplication is null!");
-    auto filesDir = NULLOPT_UNLESS(env->CallObjectMethod(context, filesDirMethod), "Returned result from getFilesDir is null!");
-    {
-        auto str = reinterpret_cast<jstring>(NULLOPT_UNLESS(env->CallObjectMethod(filesDir, absDirMethod), "Returned result from getAbsolutePath is null!"));
-        auto chars = env->GetStringUTFChars(str, nullptr);
-        result.filesDir = chars;
-        env->ReleaseStringUTFChars(str, chars);
-    }
+  auto at = NULLOPT_UNLESS(env->CallStaticObjectMethod(activityThreadClass, currentActivityThreadMethod),
+                           "Returned result from currentActivityThread is null!");
+  auto context =
+      NULLOPT_UNLESS(env->CallObjectMethod(at, getApplicationMethod), "Returned result from getApplication is null!");
+  auto filesDir =
+      NULLOPT_UNLESS(env->CallObjectMethod(context, filesDirMethod), "Returned result from getFilesDir is null!");
+  {
+    auto str = reinterpret_cast<jstring>(
+        NULLOPT_UNLESS(env->CallObjectMethod(filesDir, absDirMethod), "Returned result from getAbsolutePath is null!"));
+    auto chars = env->GetStringUTFChars(str, nullptr);
+    result.filesDir = chars;
+    env->ReleaseStringUTFChars(str, chars);
+  }
 
-    auto externalDir = NULLOPT_UNLESS(env->CallObjectMethod(context, externalDirMethod, static_cast<jstring>(nullptr)), "Returned result from getExternalFilesDir is null!");
-    {
-        auto str = reinterpret_cast<jstring>(NULLOPT_UNLESS(env->CallObjectMethod(externalDir, absDirMethod), "Returned result from getAbsolutePath is null!"));
-        auto chars = env->GetStringUTFChars(str, nullptr);
-        result.externalDir = chars;
-        env->ReleaseStringUTFChars(str, chars);
-    }
-    return result;
+  auto externalDir = NULLOPT_UNLESS(env->CallObjectMethod(context, externalDirMethod, static_cast<jstring>(nullptr)),
+                                    "Returned result from getExternalFilesDir is null!");
+  {
+    auto str = reinterpret_cast<jstring>(NULLOPT_UNLESS(env->CallObjectMethod(externalDir, absDirMethod),
+                                                        "Returned result from getAbsolutePath is null!"));
+    auto chars = env->GetStringUTFChars(str, nullptr);
+    result.externalDir = chars;
+    env->ReleaseStringUTFChars(str, chars);
+  }
+  return result;
 }
 
 std::optional<std::string> fileutils::getApplicationId() {
-    FILE *cmdline = fopen("/proc/self/cmdline", "r");
-    if (cmdline) {
-        //not sure what the actual max is, but path_max should cover it
-        char application_id[PATH_MAX] = {0};
-        fread(application_id, sizeof(application_id), 1, cmdline);
-        fclose(cmdline);
-        trimWhitespace(application_id);
-        return std::string(application_id);
-    }
-    return std::nullopt;
+  FILE* cmdline = fopen("/proc/self/cmdline", "r");
+  if (cmdline) {
+    // not sure what the actual max is, but path_max should cover it
+    char application_id[PATH_MAX] = {0};
+    fread(application_id, sizeof(application_id), 1, cmdline);
+    fclose(cmdline);
+    trimWhitespace(application_id);
+    return std::string(application_id);
+  }
+  return std::nullopt;
 }
 
-jobject fileutils::getActivityFromUnityPlayer(JNIEnv *env) {
-    jobject activity = getActivityFromUnityPlayerInternal(env);
-    if (activity == nullptr) {
-        if (env->ExceptionCheck()) env->ExceptionDescribe();
-        LOG_ERROR("libmain.getActivityFromUnityPlayer failed! See 'System.err' tag.");
-        env->ExceptionClear();
-    }
-    return activity;
+jobject fileutils::getActivityFromUnityPlayer(JNIEnv* env) {
+  jobject activity = getActivityFromUnityPlayerInternal(env);
+  if (activity == nullptr) {
+    if (env->ExceptionCheck()) env->ExceptionDescribe();
+    LOG_ERROR("libmain.getActivityFromUnityPlayer failed! See 'System.err' tag.");
+    env->ExceptionClear();
+  }
+  return activity;
 }
 
 bool fileutils::ensurePerms(JNIEnv* env, jobject activity) {
-    if (ensurePermsInternal(env, activity)) return true;
+  if (ensurePermsInternal(env, activity)) return true;
 
-    if (env->ExceptionCheck()) env->ExceptionDescribe();
-    LOG_ERROR("libmain.ensurePerms failed! See 'System.err' tag.");
-    env->ExceptionClear();
-    return false;
+  if (env->ExceptionCheck()) env->ExceptionDescribe();
+  LOG_ERROR("libmain.ensurePerms failed! See 'System.err' tag.");
+  env->ExceptionClear();
+  return false;
 }

--- a/src/fileutils.cpp
+++ b/src/fileutils.cpp
@@ -144,7 +144,9 @@ std::optional<fileutils::path_container> fileutils::getDirs(JNIEnv* env, std::st
   // Construct the path to the modloader here, as there's no point in attempting to load if we can't get the other dirs
   // as well
   fileutils::path_container result{.modloaderSearchPath =
-                                       std::filesystem::absolute("/sdcard/ModData"_fp / application_id / "Modloader")};
+                                       std::filesystem::absolute("/sdcard/ModData"_fp / application_id / "Modloader"),
+                                      .filesDir{},
+                                    .externalDir{}};
 
   ERR_CHECK(at, env->CallStaticObjectMethod(activityThreadClass, currentActivityThreadMethod));
   ERR_CHECK(context, env->CallObjectMethod(at, getApplicationMethod));

--- a/src/fileutils.cpp
+++ b/src/fileutils.cpp
@@ -50,39 +50,7 @@ jobject getActivityFromUnityPlayerInternal(JNIEnv* env) {
   ERR_CHECK(result, env->GetStaticObjectField(clazz, actField));
   return result;
 }
-bool ensurePermsWithUnity(JNIEnv* env, jobject activity, [[maybe_unused]] std::string_view application_id) {
-  ERR_CHECK(clazz, env->FindClass("com/unity3d/player/UnityPermissions"));
-  ERR_CHECK(requestUserPerms, env->GetStaticMethodID(clazz, "requestUserPermissions",
-                                                     "(Landroid/app/Activity;[Ljava/lang/String;Lcom/unity3d/player/"
-                                                     "IPermissionRequestCallbacks;)V"));
-  ERR_CHECK(waitperm_class, env->FindClass("com/unity3d/player/UnityPermissions$ModalWaitForPermissionResponse"));
-  ERR_CHECK(string_class, env->FindClass("java/lang/String"));
-  ERR_CHECK(waitperm_ctor, env->GetMethodID(waitperm_class, "<init>", "()V"));
-  ERR_CHECK(waitperm_wait, env->GetMethodID(waitperm_class, "waitForResponse", "()V"));
 
-  // The set of permissions to request broadly
-  // TODO: Attempt to see if we can create application_id based permissions here as done in ensurePermsWithAppId
-  constexpr std::array kPerms = {
-      "android.permission.WRITE_EXTERNAL_STORAGE",
-      "android.permission.MANAGE_EXTERNAL_STORAGE",
-  };
-
-  // First, create an instance of ModalWaitForPermissionResponse
-  ERR_CHECK(waitperm, env->NewObject(waitperm_class, waitperm_ctor));
-  ERR_CHECK(perms_arr, env->NewObjectArray(kPerms.size(), string_class, nullptr));
-  for (auto i = 0ULL; i < kPerms.size(); i++) {
-    ERR_CHECK(jstr, env->NewStringUTF(kPerms[i]));
-    env->SetObjectArrayElement(perms_arr, i, jstr);
-  }
-  // Call requestUserPermissions on the activity, with the permissions array and waitperm instance
-  env->CallStaticVoidMethod(clazz, requestUserPerms, activity, perms_arr, waitperm);
-  if (env->ExceptionCheck()) return false;
-  // Now wait for the response
-  // TODO: This is actually a blocking call. Ideally, we fire it off and continue and install ourselves as a callback.
-  // That way, we would get called when the perm dialog closes but won't potentially cause loading to hang.
-  env->CallVoidMethod(waitperm, waitperm_wait);
-  return !env->ExceptionCheck();
-}
 bool ensurePermsWithAppId(JNIEnv* env, jobject activity, std::string_view application_id) {
   ERR_CHECK(clazz, env->FindClass("com/unity3d/player/UnityPlayerActivity"));
   ERR_CHECK(intentClass, env->FindClass("android/content/Intent"));
@@ -92,6 +60,9 @@ bool ensurePermsWithAppId(JNIEnv* env, jobject activity, std::string_view applic
   ERR_CHECK(uriParse, env->GetStaticMethodID(uriClass, "parse", "(Ljava/lang/String;)Landroid/net/Uri;"));
   ERR_CHECK(envClass, env->FindClass("android/os/Environment"));
   ERR_CHECK(isExternalMethod, env->GetStaticMethodID(envClass, "isExternalStorageManager", "()Z"));
+  ERR_CHECK(checkSelfPermission, env->GetMethodID(clazz, "checkSelfPermission", "(Ljava/lang/String;)I"));
+  ERR_CHECK(requestPermissions, env->GetMethodID(clazz, "requestPermissions", "([Ljava/lang/String;I)V"));
+  ERR_CHECK(stringClass, env->FindClass("java/lang/String"));
 
   using namespace std::chrono_literals;
   // We loop the attempt to display permissions
@@ -101,6 +72,32 @@ bool ensurePermsWithAppId(JNIEnv* env, jobject activity, std::string_view applic
   // 2. If the delay is too excessive and causes the app to exit out from watchdog
   constexpr static auto kNumTries = 3;
   constexpr static auto kDelay = 5000ms;
+
+  {
+    const jstring perm = env->NewStringUTF("android.permission.WRITE_EXTERNAL_STORAGE");
+    const jstring perm2 = env->NewStringUTF("android.permission.MANAGE_EXTERNAL_STORAGE");
+    for (int i = 0; i < kNumTries; i++) {
+      LOG_DEBUG("Trial for permissions: %d/%d", i, kNumTries);
+      jint hasPerm = env->CallIntMethod(activity, checkSelfPermission, perm);
+      LOG_DEBUG("checkSelfPermission(WRITE_EXTERNAL_STORAGE, MANAGE_EXTERNAL_STORAGE) returned: %i", hasPerm);
+      if (hasPerm != 0) {
+        jobjectArray arr = env->NewObjectArray(2, stringClass, perm);
+        env->SetObjectArrayElement(arr, 1, perm2);
+        jint requestCode = 21326;  // the number in the alphabet for each letter in BMBF (B=2, M=13, F=6)
+        LOG_INFO("Calling requestPermissions for WRITE_EXTERNAL_STORAGE, MANAGE_EXTERNAL_STORAGE!");
+        env->CallVoidMethod(activity, requestPermissions, arr, requestCode);
+        if (env->ExceptionCheck()) return false;
+      } else {
+        LOG_DEBUG("Permission is accepted!");
+        break;
+      }
+      std::this_thread::sleep_for(kDelay);
+    }
+  }
+  // Extra permission not needed on older android versions and our method to obtain it does not work
+  if(android_get_device_api_level() < 30) {
+    return !env->ExceptionCheck();
+  }
 
   for (int i = 0; i < kNumTries; i++) {
     auto result = env->CallStaticBooleanMethod(envClass, isExternalMethod);
@@ -195,11 +192,6 @@ jobject fileutils::getActivityFromUnityPlayer(JNIEnv* env) {
 }
 
 bool fileutils::ensurePerms(JNIEnv* env, jobject activity, std::string_view application_id) {
-  // First, try to use unity. Failing that, use a fallback
-  if (ensurePermsWithUnity(env, activity, application_id)) return true;
-  if (env->ExceptionCheck()) env->ExceptionDescribe();
-  LOG_ERROR("libmain.ensurePermsWithUnity failed! See 'System.err' tag.");
-  env->ExceptionClear();
   // TODO: The correct thing to do would be to listen to the completion event and resume modloading when that happens.
   // Instead, we actually sleep the thread, which is potentially problematic.
   if (ensurePermsWithAppId(env, activity, application_id)) return true;

--- a/src/fileutils.cpp
+++ b/src/fileutils.cpp
@@ -52,7 +52,12 @@ jobject getActivityFromUnityPlayerInternal(JNIEnv* env) {
 }
 
 bool ensurePermsWithAppId(JNIEnv* env, jobject activity, std::string_view application_id) {
-  ERR_CHECK(clazz, env->FindClass("com/unity3d/player/UnityPlayerActivity"));
+  auto clazz = env->FindClass("com/unity3d/player/UnityPlayerActivity");
+  if(!clazz) {
+    env->ExceptionClear();
+    ERR_CHECK(clazz2, env->FindClass("com/unity3d/player/UnityPlayerGameActivity"));
+    clazz = clazz2;
+  }
   ERR_CHECK(checkSelfPermission, env->GetMethodID(clazz, "checkSelfPermission", "(Ljava/lang/String;)I"));
   ERR_CHECK(requestPermissions, env->GetMethodID(clazz, "requestPermissions", "([Ljava/lang/String;I)V"));
   ERR_CHECK(stringClass, env->FindClass("java/lang/String"));

--- a/src/fileutils.cpp
+++ b/src/fileutils.cpp
@@ -53,13 +53,6 @@ jobject getActivityFromUnityPlayerInternal(JNIEnv* env) {
 
 bool ensurePermsWithAppId(JNIEnv* env, jobject activity, std::string_view application_id) {
   ERR_CHECK(clazz, env->FindClass("com/unity3d/player/UnityPlayerActivity"));
-  ERR_CHECK(intentClass, env->FindClass("android/content/Intent"));
-  ERR_CHECK(intentCtorID, env->GetMethodID(intentClass, "<init>", "(Ljava/lang/String;Landroid/net/Uri;)V"));
-  ERR_CHECK(startActivity, env->GetMethodID(clazz, "startActivity", "(Landroid/content/Intent;)V"));
-  ERR_CHECK(uriClass, env->FindClass("android/net/Uri"));
-  ERR_CHECK(uriParse, env->GetStaticMethodID(uriClass, "parse", "(Ljava/lang/String;)Landroid/net/Uri;"));
-  ERR_CHECK(envClass, env->FindClass("android/os/Environment"));
-  ERR_CHECK(isExternalMethod, env->GetStaticMethodID(envClass, "isExternalStorageManager", "()Z"));
   ERR_CHECK(checkSelfPermission, env->GetMethodID(clazz, "checkSelfPermission", "(Ljava/lang/String;)I"));
   ERR_CHECK(requestPermissions, env->GetMethodID(clazz, "requestPermissions", "([Ljava/lang/String;I)V"));
   ERR_CHECK(stringClass, env->FindClass("java/lang/String"));
@@ -98,6 +91,14 @@ bool ensurePermsWithAppId(JNIEnv* env, jobject activity, std::string_view applic
   if(android_get_device_api_level() < 30) {
     return !env->ExceptionCheck();
   }
+
+  ERR_CHECK(intentClass, env->FindClass("android/content/Intent"));
+  ERR_CHECK(intentCtorID, env->GetMethodID(intentClass, "<init>", "(Ljava/lang/String;Landroid/net/Uri;)V"));
+  ERR_CHECK(startActivity, env->GetMethodID(clazz, "startActivity", "(Landroid/content/Intent;)V"));
+  ERR_CHECK(uriClass, env->FindClass("android/net/Uri"));
+  ERR_CHECK(uriParse, env->GetStaticMethodID(uriClass, "parse", "(Ljava/lang/String;)Landroid/net/Uri;"));
+  ERR_CHECK(envClass, env->FindClass("android/os/Environment"));
+  ERR_CHECK(isExternalMethod, env->GetStaticMethodID(envClass, "isExternalStorageManager", "()Z"));
 
   for (int i = 0; i < kNumTries; i++) {
     auto result = env->CallStaticBooleanMethod(envClass, isExternalMethod);

--- a/src/jni.cpp
+++ b/src/jni.cpp
@@ -1,95 +1,97 @@
-#include "log.hpp"
 #include "jni.hpp"
-#include "modloader.hpp"
+
+#include <dlfcn.h>
 
 #include <array>
-#include <string>
-#include <dlfcn.h>
 #include <filesystem>
+#include <string>
+
+#include "log.hpp"
+#include "modloader.hpp"
+
 
 namespace fs = std::filesystem;
 
 MAIN_LOCAL void* jni::unityHandle = nullptr;
 
 MAIN_LOCAL jboolean jni::load(JNIEnv* env, jobject klass, jstring str) noexcept {
-    if (unityHandle != nullptr)
-        return true;
+  if (unityHandle != nullptr) return true;
 
-    auto const directoryLength = env->GetStringUTFLength(str);
+  auto const directoryLength = env->GetStringUTFLength(str);
 
-    auto chars = env->GetStringUTFChars(str, nullptr);
-    fs::path path(chars);
-    env->ReleaseStringUTFChars(str, chars);
+  auto chars = env->GetStringUTFChars(str, nullptr);
+  fs::path path(chars);
+  env->ReleaseStringUTFChars(str, chars);
 
-    LOG_VERBOSE("Searching in %s", path.c_str());
+  LOG_VERBOSE("Searching in %s", path.c_str());
 
-    JavaVM* vm = nullptr;
+  JavaVM* vm = nullptr;
 
-    if (env->GetJavaVM(&vm) < 0) {
-        env->FatalError("Unable to retrieve Java VM"); // libmain wording
-        return false; // doesn't actually reach here
-    }
+  if (env->GetJavaVM(&vm) < 0) {
+    env->FatalError("Unable to retrieve Java VM");  // libmain wording
+    return false;                                   // doesn't actually reach here
+  }
 
-    LOG_VERBOSE("Got JVM");
+  LOG_VERBOSE("Got JVM");
 
-    modloader::load(env, path.c_str());
+  modloader::load(env, path.c_str());
 
-    path /= unityName;
-    unityHandle = dlopen(path.c_str(), RTLD_LAZY);
+  path /= unityName;
+  unityHandle = dlopen(path.c_str(), RTLD_LAZY);
+  if (unityHandle == nullptr) {
+    unityHandle = dlopen(unityName.data(), RTLD_LAZY);
     if (unityHandle == nullptr) {
-        unityHandle = dlopen(unityName.data(), RTLD_LAZY);
-        if (unityHandle == nullptr) {
-            auto err = dlerror();
-            LOG_ERROR("Could not load unity from %s: %s", path.c_str(), err);
-            std::array<char, 0x400> message = {0}; // this is what the original libmain allocates, so lets hope its enough
-                                                // and doesn't use all of the rest of our stack space
-            snprintf(message.data(), message.size(), "Unable to load library: %s [%s]", path.c_str(), err);
-            env->FatalError(message.data());
-            return false; // doesn't actually reach here
-        }
+      auto err = dlerror();
+      LOG_ERROR("Could not load unity from %s: %s", path.c_str(), err);
+      std::array<char, 0x400> message = {0};  // this is what the original libmain allocates, so lets hope its enough
+                                              // and doesn't use all of the rest of our stack space
+      snprintf(message.data(), message.size(), "Unable to load library: %s [%s]", path.c_str(), err);
+      env->FatalError(message.data());
+      return false;  // doesn't actually reach here
     }
+  }
 
-    modloader::accept_unity_handle(env, unityHandle);
+  modloader::accept_unity_handle(env, unityHandle);
 
-    auto onload = reinterpret_cast<JNI_OnLoad_t*>(dlsym(unityHandle, "JNI_OnLoad"));
-    if (onload != nullptr) {
-        if (onload(vm, nullptr) > JNI_VERSION_1_6) {
-            LOG_ERROR("unity JNI_OnLoad requested unsupported VM version");
-            env->FatalError("Unsupported VM version"); // libmain wording
-            return false; // doesn't actually reach here
-        }
-    } else {
-        LOG_WARN("unity does not have a JNI_OnLoad");
+  auto onload = reinterpret_cast<JNI_OnLoad_t*>(dlsym(unityHandle, "JNI_OnLoad"));
+  if (onload != nullptr) {
+    if (onload(vm, nullptr) > JNI_VERSION_1_6) {
+      LOG_ERROR("unity JNI_OnLoad requested unsupported VM version");
+      env->FatalError("Unsupported VM version");  // libmain wording
+      return false;                               // doesn't actually reach here
     }
+  } else {
+    LOG_WARN("unity does not have a JNI_OnLoad");
+  }
 
-    LOG_INFO("Successfully loaded and initialized %s", path.c_str());
+  LOG_INFO("Successfully loaded and initialized %s", path.c_str());
 
-    return unityHandle != nullptr;
+  return unityHandle != nullptr;
 }
 
 MAIN_LOCAL jboolean jni::unload(JNIEnv* env, jobject klass) noexcept {
-    JavaVM* vm = nullptr;
+  JavaVM* vm = nullptr;
 
-    if (env->GetJavaVM(&vm) < 0) {
-        env->FatalError("Unable to retrieve Java VM"); // libmain wording
-        return false; // doesn't actually reach here
-    }
+  if (env->GetJavaVM(&vm) < 0) {
+    env->FatalError("Unable to retrieve Java VM");  // libmain wording
+    return false;                                   // doesn't actually reach here
+  }
 
-    modloader::unload(vm);
-    
-    auto onunload = reinterpret_cast<JNI_OnUnload_t*>(dlsym(unityHandle, "JNI_OnUnload"));
-    if (onunload != nullptr) {
-        onunload(vm, nullptr);
-    } else {
-        LOG_WARN("unity does not have a JNI_OnUnload");
-    }
+  modloader::unload(vm);
 
-    int code = dlclose(unityHandle);
+  auto onunload = reinterpret_cast<JNI_OnUnload_t*>(dlsym(unityHandle, "JNI_OnUnload"));
+  if (onunload != nullptr) {
+    onunload(vm, nullptr);
+  } else {
+    LOG_WARN("unity does not have a JNI_OnUnload");
+  }
 
-    if (code != 0) {
-        LOG_ERROR("Error occurred closing unity: %s", dlerror());
-    } else {
-        LOG_VERBOSE("Successfully closed unity");
-    }
-    return true;
+  int code = dlclose(unityHandle);
+
+  if (code != 0) {
+    LOG_ERROR("Error occurred closing unity: %s", dlerror());
+  } else {
+    LOG_VERBOSE("Successfully closed unity");
+  }
+  return true;
 }

--- a/src/jni.cpp
+++ b/src/jni.cpp
@@ -9,9 +9,9 @@
 
 namespace fs = std::filesystem;
 
-void* jni::unityHandle = nullptr;
+MAIN_LOCAL void* jni::unityHandle = nullptr;
 
-jboolean jni::load(JNIEnv* env, jobject klass, jstring str) noexcept {
+MAIN_LOCAL jboolean jni::load(JNIEnv* env, jobject klass, jstring str) noexcept {
     if (unityHandle != nullptr)
         return true;
 
@@ -32,7 +32,7 @@ jboolean jni::load(JNIEnv* env, jobject klass, jstring str) noexcept {
 
     LOG_VERBOSE("Got JVM");
 
-    modloader::load(env);
+    modloader::load(env, path.c_str());
 
     path /= unityName;
     unityHandle = dlopen(path.c_str(), RTLD_LAZY);
@@ -67,7 +67,7 @@ jboolean jni::load(JNIEnv* env, jobject klass, jstring str) noexcept {
     return unityHandle != nullptr;
 }
 
-jboolean jni::unload(JNIEnv* env, jobject klass) noexcept {
+MAIN_LOCAL jboolean jni::unload(JNIEnv* env, jobject klass) noexcept {
     JavaVM* vm = nullptr;
 
     if (env->GetJavaVM(&vm) < 0) {
@@ -75,7 +75,7 @@ jboolean jni::unload(JNIEnv* env, jobject klass) noexcept {
         return false; // doesn't actually reach here
     }
 
-    modloader::unload(env);
+    modloader::unload(vm);
     
     auto onunload = reinterpret_cast<JNI_OnUnload_t*>(dlsym(unityHandle, "JNI_OnUnload"));
     if (onunload != nullptr) {

--- a/src/jni.cpp
+++ b/src/jni.cpp
@@ -9,15 +9,12 @@
 #include "log.hpp"
 #include "modloader.hpp"
 
-
 namespace fs = std::filesystem;
 
 MAIN_LOCAL void* jni::unityHandle = nullptr;
 
-MAIN_LOCAL jboolean jni::load(JNIEnv* env, jobject klass, jstring str) noexcept {
+MAIN_LOCAL jboolean jni::load(JNIEnv* env, [[maybe_unused]] jobject klass, jstring str) noexcept {
   if (unityHandle != nullptr) return true;
-
-  auto const directoryLength = env->GetStringUTFLength(str);
 
   auto chars = env->GetStringUTFChars(str, nullptr);
   fs::path path(chars);
@@ -69,7 +66,7 @@ MAIN_LOCAL jboolean jni::load(JNIEnv* env, jobject klass, jstring str) noexcept 
   return unityHandle != nullptr;
 }
 
-MAIN_LOCAL jboolean jni::unload(JNIEnv* env, jobject klass) noexcept {
+MAIN_LOCAL jboolean jni::unload(JNIEnv* env, [[maybe_unused]] jobject klass) noexcept {
   JavaVM* vm = nullptr;
 
   if (env->GetJavaVM(&vm) < 0) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,7 +1,6 @@
 #include <array>
 
 #include "log.hpp"
-#include "main.hpp"
 #include "jni.hpp"
 #include "modloader.hpp"
 #include "fileutils.hpp"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,47 +1,45 @@
 #include <array>
 
 #include "_config.h"
-#include "log.hpp"
-#include "jni.hpp"
-#include "modloader.hpp"
 #include "fileutils.hpp"
+#include "jni.hpp"
+#include "log.hpp"
+#include "modloader.hpp"
 
 #define EXPORT_FUNC extern "C" MAIN_EXPORT
 
 namespace {
-constexpr std::array<JNINativeMethod, 2> NativeLoader_bindings = {{
-    { "load",   "(Ljava/lang/String;)Z", (void*)&jni::load   },
-    { "unload", "()Z",                   (void*)&jni::unload }
-}};
+constexpr std::array<JNINativeMethod, 2> NativeLoader_bindings = {
+    {{"load", "(Ljava/lang/String;)Z", (void*)&jni::load}, {"unload", "()Z", (void*)&jni::unload}}};
 }
 
 EXPORT_FUNC jint JNI_OnLoad(JavaVM* vm, void*) {
-    JNIEnv* env = nullptr;
+  JNIEnv* env = nullptr;
 
-    LOG_INFO("JNI_OnLoad called, linking JNI methods");
+  LOG_INFO("JNI_OnLoad called, linking JNI methods");
 
-    vm->AttachCurrentThread(&env, nullptr);
-    auto klass = env->FindClass("com/unity3d/player/NativeLoader");
+  vm->AttachCurrentThread(&env, nullptr);
+  auto klass = env->FindClass("com/unity3d/player/NativeLoader");
 
-    auto ret = env->RegisterNatives(klass, NativeLoader_bindings.data(), NativeLoader_bindings.size());
+  auto ret = env->RegisterNatives(klass, NativeLoader_bindings.data(), NativeLoader_bindings.size());
 
-    if (ret < 0) {
-        LOG_ERROR("RegisterNatives failed with %d", ret);
-        // this is such a useless error message because the original libmain does this
-        env->FatalError("com/unity3d/player/NativeLoader");
+  if (ret < 0) {
+    LOG_ERROR("RegisterNatives failed with %d", ret);
+    // this is such a useless error message because the original libmain does this
+    env->FatalError("com/unity3d/player/NativeLoader");
 
-        return -1;
-    }
+    return -1;
+  }
 
-    LOG_VERBOSE("Calling modloader preload");
-    modloader::preload(env);
-    
-    LOG_INFO("JNI_OnLoad done!");
+  LOG_VERBOSE("Calling modloader preload");
+  modloader::preload(env);
 
-    return JNI_VERSION_1_6;
+  LOG_INFO("JNI_OnLoad done!");
+
+  return JNI_VERSION_1_6;
 }
 
 EXPORT_FUNC void JNI_OnUnload(JavaVM* vm, void*) {
-    LOG_INFO("JNI_OnUnload called!");
-    modloader::unload(vm);
+  LOG_INFO("JNI_OnUnload called!");
+  modloader::unload(vm);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,16 +1,19 @@
 #include <array>
 
+#include "_config.h"
 #include "log.hpp"
 #include "jni.hpp"
 #include "modloader.hpp"
 #include "fileutils.hpp"
 
-#define EXPORT_FUNC extern "C" __attribute__((visibility("default")))
+#define EXPORT_FUNC extern "C" MAIN_EXPORT
 
+namespace {
 constexpr std::array<JNINativeMethod, 2> NativeLoader_bindings = {{
     { "load",   "(Ljava/lang/String;)Z", (void*)&jni::load   },
     { "unload", "()Z",                   (void*)&jni::unload }
 }};
+}
 
 EXPORT_FUNC jint JNI_OnLoad(JavaVM* vm, void*) {
     JNIEnv* env = nullptr;
@@ -24,8 +27,8 @@ EXPORT_FUNC jint JNI_OnLoad(JavaVM* vm, void*) {
 
     if (ret < 0) {
         LOG_ERROR("RegisterNatives failed with %d", ret);
-
-        env->FatalError("com/unity3d/player/NativeLoader"); // this is such a useless fucking error message because the original libmain does this
+        // this is such a useless error message because the original libmain does this
+        env->FatalError("com/unity3d/player/NativeLoader");
 
         return -1;
     }
@@ -40,4 +43,5 @@ EXPORT_FUNC jint JNI_OnLoad(JavaVM* vm, void*) {
 
 EXPORT_FUNC void JNI_OnUnload(JavaVM* vm, void*) {
     LOG_INFO("JNI_OnUnload called!");
+    modloader::unload(vm);
 }

--- a/src/modloader.cpp
+++ b/src/modloader.cpp
@@ -162,6 +162,7 @@ MAIN_LOCAL void modloader::preload(JNIEnv* env) noexcept {
     LOG_WARN("preload: Failed to get paths! Stopping load.");
     return;
   }
+  LOG_DEBUG("Found: files: %s, external: %s", pathContainer->filesDir.c_str(), pathContainer->externalDir.c_str());
 
   auto result = findAndOpenModloader(*pathContainer);
   if (!result) {

--- a/src/modloader.cpp
+++ b/src/modloader.cpp
@@ -3,103 +3,100 @@
 #include "fileutils.hpp"
 
 #include <dlfcn.h>
+#include <system_error>
 
 namespace fs = std::filesystem;
 
 void* modloader::modloaderHandle = nullptr;
 
 void modloader::preload(JNIEnv* env) noexcept {
-    LOG_VERBOSE("Attempting to load modloader in modloader::preload()");
+    LOG_VERBOSE("preload: Attempting to load modloader");
 
     auto applicationId = fileutils::getApplicationId();
     if(!applicationId) {
-        LOG_WARN("Could get ApplicationId");
+        LOG_WARN("preload: Failed to get ApplicationId");
         return;
     }
-    auto filesDir = fileutils::getFilesDir(env);
-    if(!filesDir) {
-        LOG_WARN("Could get FilesDir");
+    auto pathContainer = fileutils::getDirs(env);
+    if(!pathContainer) {
+        LOG_WARN("preload: Failed to get path container");
         return;
     }
 
-    fs::path src = fs::path("/sdcard/Android/data") / applicationId.value() / "files" / modloaderName.data();
-    fs::path modloaderPath = filesDir.value() / modloaderName.data();
+    fs::path src(pathContainer->externalDir / modloaderName);
+    fs::path modloaderPath(pathContainer->filesDir / modloaderName);
 
-    if (!fs::exists(src)) {
-        LOG_WARN("Could find modloader at %s", src.c_str());
+    std::error_code error_code;
+    if (!fs::exists(src, error_code)) {
+        LOG_WARN("preload: Failed to find modloader at %s (error: %s)", src.c_str(), error_code.message().c_str());
         return;
     }
-    try {
-        if(!fs::copy_file(src, modloaderPath, fs::copy_options::overwrite_existing)) {
-            LOG_WARN("Could copy %s to %s", src.c_str(), modloaderPath.c_str());
-            return;
-        }
-    } catch(fs::filesystem_error& e) {
-        LOG_WARN("Could copy %s to %s: %s", src.c_str(), modloaderPath.c_str(), e.what());
+    if (!fs::copy_file(src, modloaderPath, fs::copy_options::overwrite_existing, error_code)) {
+        LOG_WARN("preload: Failed to copy %s to %s (error: %s)", src.c_str(), modloaderPath.c_str(), error_code.message().c_str());
         return;
     }
     
-    modloaderHandle = dlopen(modloaderPath.c_str(), RTLD_LAZY);
+    modloaderHandle = dlopen(modloaderPath.c_str(), RTLD_LAZY | RTLD_GLOBAL);
     if (modloaderHandle == nullptr) {
-        LOG_WARN("Could not load %s: %s", modloaderPath.c_str(), dlerror());
+        LOG_WARN("preload: Could not load %s: %s", modloaderPath.c_str(), dlerror());
         return;
     }
 
-    LOG_VERBOSE("%s loaded", modloaderPath.c_str());
+    LOG_VERBOSE("preload: Loaded modloader: %s", modloaderPath.c_str());
 
-    auto preload = reinterpret_cast<preload_t*>(dlsym(modloaderHandle, "modloader_preload"));
+    auto preload = reinterpret_cast<preload_t*>(dlsym(modloaderHandle, preloadName.data()));
     if (preload == nullptr) {
-        LOG_WARN("%s does not have modloader_preload: %s", modloaderPath.c_str(), dlerror());
+        LOG_WARN("preload: %s does not have %s: %s", preloadName.data(), modloaderPath.c_str(), dlerror());
         return;
     }
 
-    LOG_VERBOSE("Calling modloader_preload");
-    preload(env, modloaderPath.c_str());
+    LOG_VERBOSE("preload: Calling %s", preloadName.data());
+    preload(env, modloaderPath.c_str(), pathContainer->filesDir.c_str(), pathContainer->externalDir.c_str());
 
-    LOG_VERBOSE("Preloading done");
+    LOG_VERBOSE("preload: Preloading done");
 }
 
 void modloader::load(JNIEnv* env) noexcept { 
     if (modloaderHandle == nullptr) {
-        LOG_WARN("Modloader not loaded!");
+        LOG_WARN("load: Modloader not loaded!");
         return;
     }
-    auto load = reinterpret_cast<load_t*>(dlsym(modloaderHandle, "modloader_load"));
+    auto load = reinterpret_cast<load_t*>(dlsym(modloaderHandle, loadName.data()));
     if (load == nullptr) {
-        LOG_WARN("Couldn't find modloader_load: %s", dlerror());
+        LOG_WARN("load: Failed to find %s: %s", loadName.data(), dlerror());
         return;
     }
-    LOG_VERBOSE("Calling modloader_load");
+    LOG_VERBOSE("load: Calling %s", loadName.data());
     load(env);
-    LOG_VERBOSE("Loading done");
+    LOG_VERBOSE("load: Loading done");
 }
 
 void modloader::accept_unity_handle(JNIEnv* env, void* unityHandle) noexcept {
     if (modloaderHandle == nullptr) {
-        LOG_WARN("Modloader not loaded!");
+        LOG_WARN("accept_unity_handle: Modloader not loaded!");
         return;
     }
-    auto accept_unity_handle = reinterpret_cast<accept_unity_handle_t*>(dlsym(modloaderHandle, "modloader_accept_unity_handle"));
+    auto accept_unity_handle = reinterpret_cast<accept_unity_handle_t*>(dlsym(modloaderHandle, accept_unity_handleName.data()));
     if (accept_unity_handle == nullptr) {
-        LOG_WARN("Couldn't find modloader_accept_unity_handle: %s", dlerror());
+        LOG_WARN("accept_unity_handle: Failed to find %s: %s", accept_unity_handleName.data(), dlerror());
         return;
     }
-    LOG_VERBOSE("Calling modloader_accept_unity_handle");
+    LOG_VERBOSE("accept_unity_handle: Calling %s", accept_unity_handleName.data());
     accept_unity_handle(env, unityHandle);
-    LOG_VERBOSE("Init done");
+    LOG_VERBOSE("accept_unity_handle: Init done");
 }
 
 void modloader::unload(JNIEnv* env) noexcept {
     if (modloaderHandle == nullptr) {
-        LOG_WARN("Modloader not loaded!");
+        LOG_WARN("unload: Modloader not loaded!");
         return;
     }
-    auto unload = reinterpret_cast<unload_t*>(dlsym(modloaderHandle, "modloader_unload"));
+    auto unload = reinterpret_cast<unload_t*>(dlsym(modloaderHandle, unloadName.data()));
     if (unload == nullptr) {
-        LOG_WARN("Couldn't find modloader_unload: %s", dlerror());
+        LOG_WARN("unload: Failed to find %s: %s", unloadName.data(), dlerror());
         return;
     }
-    LOG_VERBOSE("Calling modloader_unload");
+    LOG_VERBOSE("unload: Calling %s", unloadName.data());
     unload(env);
-    LOG_VERBOSE("Unload done");
+    LOG_VERBOSE("unload: Unload done");
 }

--- a/src/modloader.cpp
+++ b/src/modloader.cpp
@@ -1,109 +1,114 @@
-#include "log.hpp"
 #include "modloader.hpp"
-#include "fileutils.hpp"
 
 #include <dlfcn.h>
+
 #include <system_error>
+
+#include "fileutils.hpp"
+#include "log.hpp"
 
 namespace fs = std::filesystem;
 
 MAIN_LOCAL void* modloader::modloaderHandle = nullptr;
 
 MAIN_LOCAL void modloader::preload(JNIEnv* env) noexcept {
-    LOG_VERBOSE("preload: Attempting to acquire activity and permissions");
-    jobject activity = fileutils::getActivityFromUnityPlayer(env);
-    if (!activity) [[unlikely]] {
-        LOG_WARN("preload: Failed to find UnityPlayer activity!");
-    } else {
-        fileutils::ensurePerms(env, activity);
-    }
-    LOG_VERBOSE("preload: Attempting to load modloader");
+  LOG_VERBOSE("preload: Attempting to acquire activity and permissions");
+  jobject activity = fileutils::getActivityFromUnityPlayer(env);
+  if (!activity) [[unlikely]] {
+    LOG_WARN("preload: Failed to find UnityPlayer activity!");
+  } else {
+    fileutils::ensurePerms(env, activity);
+  }
+  LOG_VERBOSE("preload: Attempting to load modloader");
 
-    auto applicationId = fileutils::getApplicationId();
-    if(!applicationId) {
-        LOG_WARN("preload: Failed to get ApplicationId");
-        return;
-    }
-    auto pathContainer = fileutils::getDirs(env);
-    if(!pathContainer) {
-        LOG_WARN("preload: Failed to get path container");
-        return;
-    }
+  auto applicationId = fileutils::getApplicationId();
+  if (!applicationId) {
+    LOG_WARN("preload: Failed to get ApplicationId");
+    return;
+  }
+  auto pathContainer = fileutils::getDirs(env);
+  if (!pathContainer) {
+    LOG_WARN("preload: Failed to get path container");
+    return;
+  }
 
-    fs::path src(pathContainer->externalDir / modloaderName);
-    fs::path modloaderPath(pathContainer->filesDir / modloaderName);
+  fs::path src(pathContainer->externalDir / modloaderName);
+  fs::path modloaderPath(pathContainer->filesDir / modloaderName);
 
-    std::error_code error_code;
-    if (!fs::exists(src, error_code)) {
-        LOG_WARN("preload: Failed to find modloader at %s (error: %s)", src.c_str(), error_code.message().c_str());
-        return;
-    }
-    if (!fs::copy_file(src, modloaderPath, fs::copy_options::overwrite_existing, error_code)) {
-        LOG_WARN("preload: Failed to copy %s to %s (error: %s)", src.c_str(), modloaderPath.c_str(), error_code.message().c_str());
-        return;
-    }
-    
-    modloaderHandle = dlopen(modloaderPath.c_str(), RTLD_LAZY | RTLD_GLOBAL);
-    if (modloaderHandle == nullptr) {
-        LOG_WARN("preload: Could not load %s: %s", modloaderPath.c_str(), dlerror());
-        return;
-    }
+  std::error_code error_code;
+  if (!fs::exists(src, error_code)) {
+    LOG_WARN("preload: Failed to find modloader at %s (error: %s)", src.c_str(), error_code.message().c_str());
+    return;
+  }
+  if (!fs::copy_file(src, modloaderPath, fs::copy_options::overwrite_existing, error_code)) {
+    LOG_WARN("preload: Failed to copy %s to %s (error: %s)", src.c_str(), modloaderPath.c_str(),
+             error_code.message().c_str());
+    return;
+  }
 
-    LOG_VERBOSE("preload: Loaded modloader: %s", modloaderPath.c_str());
+  modloaderHandle = dlopen(modloaderPath.c_str(), RTLD_LAZY | RTLD_GLOBAL);
+  if (modloaderHandle == nullptr) {
+    LOG_WARN("preload: Could not load %s: %s", modloaderPath.c_str(), dlerror());
+    return;
+  }
 
-    auto preload = reinterpret_cast<preload_t*>(dlsym(modloaderHandle, preloadName.data()));
-    if (preload == nullptr) {
-        LOG_WARN("preload: %s does not have %s: %s", preloadName.data(), modloaderPath.c_str(), dlerror());
-        return;
-    }
+  LOG_VERBOSE("preload: Loaded modloader: %s", modloaderPath.c_str());
 
-    LOG_VERBOSE("preload: Calling %s", preloadName.data());
-    preload(env, applicationId->c_str(), modloaderPath.c_str(), pathContainer->filesDir.c_str(), pathContainer->externalDir.c_str());
+  auto preload = reinterpret_cast<preload_t*>(dlsym(modloaderHandle, preloadName.data()));
+  if (preload == nullptr) {
+    LOG_WARN("preload: %s does not have %s: %s", preloadName.data(), modloaderPath.c_str(), dlerror());
+    return;
+  }
 
-    LOG_VERBOSE("preload: Preloading done");
+  LOG_VERBOSE("preload: Calling %s", preloadName.data());
+  preload(env, applicationId->c_str(), modloaderPath.c_str(), pathContainer->filesDir.c_str(),
+          pathContainer->externalDir.c_str());
+
+  LOG_VERBOSE("preload: Preloading done");
 }
 
-MAIN_LOCAL void modloader::load(JNIEnv* env, char const* soDir) noexcept { 
-    if (modloaderHandle == nullptr) {
-        LOG_WARN("load: Modloader not loaded!");
-        return;
-    }
-    auto load = reinterpret_cast<load_t*>(dlsym(modloaderHandle, loadName.data()));
-    if (load == nullptr) {
-        LOG_WARN("load: Failed to find %s: %s", loadName.data(), dlerror());
-        return;
-    }
-    LOG_VERBOSE("load: Calling %s with soDir: %s", loadName.data(), soDir);
-    load(env, soDir);
-    LOG_VERBOSE("load: Loading done");
+MAIN_LOCAL void modloader::load(JNIEnv* env, char const* soDir) noexcept {
+  if (modloaderHandle == nullptr) {
+    LOG_WARN("load: Modloader not loaded!");
+    return;
+  }
+  auto load = reinterpret_cast<load_t*>(dlsym(modloaderHandle, loadName.data()));
+  if (load == nullptr) {
+    LOG_WARN("load: Failed to find %s: %s", loadName.data(), dlerror());
+    return;
+  }
+  LOG_VERBOSE("load: Calling %s with soDir: %s", loadName.data(), soDir);
+  load(env, soDir);
+  LOG_VERBOSE("load: Loading done");
 }
 
 MAIN_LOCAL void modloader::accept_unity_handle(JNIEnv* env, void* unityHandle) noexcept {
-    if (modloaderHandle == nullptr) {
-        LOG_WARN("accept_unity_handle: Modloader not loaded!");
-        return;
-    }
-    auto accept_unity_handle = reinterpret_cast<accept_unity_handle_t*>(dlsym(modloaderHandle, accept_unity_handleName.data()));
-    if (accept_unity_handle == nullptr) {
-        LOG_WARN("accept_unity_handle: Failed to find %s: %s", accept_unity_handleName.data(), dlerror());
-        return;
-    }
-    LOG_VERBOSE("accept_unity_handle: Calling %s", accept_unity_handleName.data());
-    accept_unity_handle(env, unityHandle);
-    LOG_VERBOSE("accept_unity_handle: Init done");
+  if (modloaderHandle == nullptr) {
+    LOG_WARN("accept_unity_handle: Modloader not loaded!");
+    return;
+  }
+  auto accept_unity_handle =
+      reinterpret_cast<accept_unity_handle_t*>(dlsym(modloaderHandle, accept_unity_handleName.data()));
+  if (accept_unity_handle == nullptr) {
+    LOG_WARN("accept_unity_handle: Failed to find %s: %s", accept_unity_handleName.data(), dlerror());
+    return;
+  }
+  LOG_VERBOSE("accept_unity_handle: Calling %s", accept_unity_handleName.data());
+  accept_unity_handle(env, unityHandle);
+  LOG_VERBOSE("accept_unity_handle: Init done");
 }
 
 MAIN_LOCAL void modloader::unload(JavaVM* vm) noexcept {
-    if (modloaderHandle == nullptr) {
-        LOG_WARN("unload: Modloader not loaded!");
-        return;
-    }
-    auto unload = reinterpret_cast<unload_t*>(dlsym(modloaderHandle, unloadName.data()));
-    if (unload == nullptr) {
-        LOG_WARN("unload: Failed to find %s: %s", unloadName.data(), dlerror());
-        return;
-    }
-    LOG_VERBOSE("unload: Calling %s", unloadName.data());
-    unload(vm);
-    LOG_VERBOSE("unload: Unload done");
+  if (modloaderHandle == nullptr) {
+    LOG_WARN("unload: Modloader not loaded!");
+    return;
+  }
+  auto unload = reinterpret_cast<unload_t*>(dlsym(modloaderHandle, unloadName.data()));
+  if (unload == nullptr) {
+    LOG_WARN("unload: Failed to find %s: %s", unloadName.data(), dlerror());
+    return;
+  }
+  LOG_VERBOSE("unload: Calling %s", unloadName.data());
+  unload(vm);
+  LOG_VERBOSE("unload: Unload done");
 }

--- a/src/modloader.cpp
+++ b/src/modloader.cpp
@@ -1,7 +1,10 @@
 #include "modloader.hpp"
 
 #include <dlfcn.h>
+#include <sys/stat.h>
 
+#include <filesystem>
+#include <optional>
 #include <system_error>
 
 #include "fileutils.hpp"
@@ -9,48 +12,164 @@
 
 namespace fs = std::filesystem;
 
+namespace {
+// Get status type as string
+const char* status_type(fs::file_type const type) {
+  switch (type) {
+    case fs::file_type::none:
+      return "none";
+    case fs::file_type::not_found:
+      return "not found";
+    case fs::file_type::regular:
+      return "regular";
+    case fs::file_type::directory:
+      return "directory";
+    case fs::file_type::symlink:
+      return "symlink";
+    case fs::file_type::block:
+      return "block";
+    case fs::file_type::character:
+      return "character";
+    case fs::file_type::fifo:
+      return "fifo";
+    case fs::file_type::socket:
+      return "socket";
+    case fs::file_type::unknown:
+    default:
+      return "unknown";
+  }
+}
+
+// Get stats and status of file
+#if defined(__aarch64__) && !defined(NO_STAT_DUMPS)
+void statdump(fs::path const& path) {
+  struct stat64 buffer {};
+  if (stat64(path.c_str(), &buffer) != 0) {
+    LOG_DEBUG("stat64 of file: %s failed: %d, %s", path.c_str(), errno, strerror(errno));
+  } else {
+    LOG_DEBUG(
+        "file: %s, dev: %lu, ino: %lu, mode: %d, nlink: %d, uid: %d, gid: %d, rdid: %lu, sz: %ld, atime: %ld, "
+        "mtime: %ld, ctime: %ld",
+        path.c_str(), buffer.st_dev, buffer.st_ino, buffer.st_mode, buffer.st_nlink, buffer.st_uid, buffer.st_gid,
+        buffer.st_rdev, buffer.st_size, buffer.st_atime, buffer.st_mtime, buffer.st_ctime);
+    std::error_code err{};
+    auto status = fs::status(path, err);
+    if (err) {
+      LOG_ERROR("Failed to get status of path: %s", path.c_str());
+      return;
+    }
+    LOG_DEBUG("File: %s, type: %s, perms: 0x%x", path.c_str(), status_type(status.type()), status.permissions());
+  }
+}
+#else
+void statdump([[maybe_unused]] fs::path const& path) {}
+#endif
+
+#define HANDLE_ERR(err)                                                             \
+  if (err) {                                                                        \
+    LOG_ERROR("Failed path operation: %d: %s", err.value(), err.message().c_str()); \
+    return {};                                                                      \
+  }
+
+struct FindResult {
+  void* handle;
+  fs::path path;
+  fs::path source;
+};
+
+[[nodiscard]] std::optional<FindResult> findAndOpenModloader(fileutils::path_container const& container) {
+  auto const& path = container.modloaderSearchPath;
+  LOG_DEBUG("Attempting modloader search at: %s", path.c_str());
+  statdump(path);
+  // Find the first .so file in the modloader directory and open it
+  std::error_code err{};
+  fs::directory_iterator iter(container.modloaderSearchPath, fs::directory_options::skip_permission_denied, err);
+  HANDLE_ERR(err);
+  for (auto const& entry : iter) {
+    // First, handle an error if there is one
+    HANDLE_ERR(err);
+    // Next, check to see if this entry is a .so
+    if (entry.is_regular_file(err) && entry.path().filename().string().ends_with(".so")) {
+      // We found a viable option!
+      auto src = fs::absolute(entry.path());
+      statdump(src);
+      auto modloaderPath = fs::absolute(container.filesDir / entry.path().filename());
+      if (!fs::copy_file(src, modloaderPath, fs::copy_options::overwrite_existing, err)) {
+        // Gracefully handle errors on copy + overwrite of modloader candidate
+        LOG_WARN("findAndOpenModloader: Failed to copy %s to %s (error: %s)", src.c_str(), modloaderPath.c_str(),
+                 err.message().c_str());
+        err.clear();
+        // Try other candidates
+        continue;
+      }
+      // Ensure destination file has correct permissions
+      auto flags = S_IRUSR | S_IWUSR | S_IXUSR | S_IRGRP | S_IXGRP | S_IWGRP | S_IROTH | S_IXOTH;
+      if (chmod(modloaderPath.c_str(), flags) < 0) {
+        LOG_WARN("Failed to chmod %s with flags: %x! errno: %d, %s", modloaderPath.c_str(), flags, errno,
+                 strerror(errno));
+        continue;
+      }
+      LOG_VERBOSE("Stat dump before dlopen...");
+      statdump(modloaderPath);
+      // Finally, try to dlopen
+      auto modloaderHandle = dlopen(modloaderPath.c_str(), RTLD_LAZY | RTLD_GLOBAL);
+      if (modloaderHandle == nullptr) {
+        LOG_WARN("preload: Could not load %s: %s", modloaderPath.c_str(), dlerror());
+        continue;
+      }
+      // If everything worked, return
+      return FindResult{
+          .handle = modloaderHandle,
+          .path = modloaderPath,
+          .source = src,
+      };
+    }
+    if (err) {
+      // Gracefully handle errors where we cannot check if the file is valid by skipping
+      LOG_WARN("Failed to check if file was valid: %s (error: %s)", entry.path().c_str(), err.message().c_str());
+      err.clear();
+    }
+  }
+  // At this point, we had NO candidates for a modloader in our modloader directory.
+  // Exit gracefully and continue game load
+  LOG_WARN("Found no candidate modloaders in: %s", path.c_str());
+  return {};
+}
+
+}  // namespace
+
 MAIN_LOCAL void* modloader::modloaderHandle = nullptr;
 
 MAIN_LOCAL void modloader::preload(JNIEnv* env) noexcept {
+  LOG_VERBOSE("preload: Getting application id");
+  auto applicationId = fileutils::getApplicationId();
+  if (!applicationId) [[unlikely]] {
+    LOG_WARN("preload: Failed to get ApplicationId");
+    return;
+  }
+  LOG_VERBOSE("preload: Application ID: %s", applicationId->c_str());
   LOG_VERBOSE("preload: Attempting to acquire activity and permissions");
   jobject activity = fileutils::getActivityFromUnityPlayer(env);
   if (!activity) [[unlikely]] {
     LOG_WARN("preload: Failed to find UnityPlayer activity!");
   } else {
-    fileutils::ensurePerms(env, activity);
+    fileutils::ensurePerms(env, activity, *applicationId);
   }
-  LOG_VERBOSE("preload: Attempting to load modloader");
+  LOG_VERBOSE("preload: Attempting to find dirs");
 
-  auto applicationId = fileutils::getApplicationId();
-  if (!applicationId) {
-    LOG_WARN("preload: Failed to get ApplicationId");
-    return;
-  }
-  auto pathContainer = fileutils::getDirs(env);
+  auto pathContainer = fileutils::getDirs(env, *applicationId);
   if (!pathContainer) {
-    LOG_WARN("preload: Failed to get path container");
+    LOG_WARN("preload: Failed to get paths! Stopping load.");
     return;
   }
 
-  fs::path src(pathContainer->externalDir / modloaderName);
-  fs::path modloaderPath(pathContainer->filesDir / modloaderName);
-
-  std::error_code error_code;
-  if (!fs::exists(src, error_code)) {
-    LOG_WARN("preload: Failed to find modloader at %s (error: %s)", src.c_str(), error_code.message().c_str());
+  auto result = findAndOpenModloader(*pathContainer);
+  if (!result) {
+    LOG_WARN("Failed to find valid modloader, continuing load anyways...");
     return;
   }
-  if (!fs::copy_file(src, modloaderPath, fs::copy_options::overwrite_existing, error_code)) {
-    LOG_WARN("preload: Failed to copy %s to %s (error: %s)", src.c_str(), modloaderPath.c_str(),
-             error_code.message().c_str());
-    return;
-  }
-
-  modloaderHandle = dlopen(modloaderPath.c_str(), RTLD_LAZY | RTLD_GLOBAL);
-  if (modloaderHandle == nullptr) {
-    LOG_WARN("preload: Could not load %s: %s", modloaderPath.c_str(), dlerror());
-    return;
-  }
+  modloaderHandle = result->handle;
+  auto const& modloaderPath = result->path;
 
   LOG_VERBOSE("preload: Loaded modloader: %s", modloaderPath.c_str());
 
@@ -61,7 +180,7 @@ MAIN_LOCAL void modloader::preload(JNIEnv* env) noexcept {
   }
 
   LOG_VERBOSE("preload: Calling %s", preloadName.data());
-  preload(env, applicationId->c_str(), modloaderPath.c_str(), pathContainer->filesDir.c_str(),
+  preload(env, applicationId->c_str(), modloaderPath.c_str(), result->source.c_str(), pathContainer->filesDir.c_str(),
           pathContainer->externalDir.c_str());
 
   LOG_VERBOSE("preload: Preloading done");

--- a/src/modloader.cpp
+++ b/src/modloader.cpp
@@ -58,7 +58,7 @@ void statdump(fs::path const& path) {
       LOG_ERROR("Failed to get status of path: %s", path.c_str());
       return;
     }
-    LOG_DEBUG("File: %s, type: %s, perms: 0x%x", path.c_str(), status_type(status.type()), status.permissions());
+    LOG_DEBUG("File: %s, type: %s, perms: 0x%x", path.c_str(), status_type(status.type()), (unsigned int)status.permissions());
   }
 }
 #else


### PR DESCRIPTION
Better error checking, improved forwarding of parameters to the opened modloader and ensure C compatible friendliness.

This is in preparation for the SL2 changes and the general A11-A13 compatibility